### PR TITLE
Add GTSRB dataset

### DIFF
--- a/src/cupbearer/data/__init__.py
+++ b/src/cupbearer/data/__init__.py
@@ -6,13 +6,14 @@ from ._shared import TestDataMix as TestDataMix
 from ._shared import numpy_collate as numpy_collate
 from .adversarial import AdversarialExampleConfig
 from .backdoors import CornerPixelBackdoor, NoiseBackdoor, WanetBackdoor
-from .pytorch import CIFAR10, MNIST, PytorchConfig
+from .pytorch import CIFAR10, GTSRB, MNIST, PytorchConfig
 from .toy_ambiguous_features import ToyFeaturesConfig
 
 DATASETS = {
     "pytorch": PytorchConfig,
     "mnist": MNIST,
     "cifar10": CIFAR10,
+    "gtsrb": GTSRB,
     "from_run": TrainDataFromRun,
     "adversarial": AdversarialExampleConfig,
     "toy_features": ToyFeaturesConfig,

--- a/src/cupbearer/data/_shared.py
+++ b/src/cupbearer/data/_shared.py
@@ -22,6 +22,8 @@ class Transform(BaseConfig, ABC):
 
 @dataclass
 class AdaptedTransform(Transform, ABC):
+    """Adapt a transform designed to work on inputs to work on img, label pairs."""
+
     @abstractmethod
     def __img_call__(self, img):
         pass

--- a/src/cupbearer/data/_shared.py
+++ b/src/cupbearer/data/_shared.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 import numpy as np
 from torch.utils.data import Dataset, Subset
 from torchvision.transforms import Compose
-from torchvision.transforms.functional import resize, InterpolationMode
+from torchvision.transforms.functional import InterpolationMode, resize
 
 from cupbearer.utils.scripts import load_config
 from cupbearer.utils.utils import BaseConfig
@@ -25,7 +25,7 @@ class AdaptedTransform(Transform, ABC):
     @abstractmethod
     def __img_call__(self, img):
         pass
-    
+
     def __rest_call__(self, *rest):
         return (*rest,)
 
@@ -103,7 +103,7 @@ class Resize(AdaptedTransform):
     size: tuple[int, ...]
     interpolation: InterpolationMode = InterpolationMode.BILINEAR
     max_size: Optional[int] = None
-    antialias: Optional[Union[str, bool]] = 'warn'
+    antialias: Optional[Union[str, bool]] = "warn"
 
     def __img_call__(self, img):
         return resize(

--- a/src/cupbearer/data/backdoor_data.py
+++ b/src/cupbearer/data/backdoor_data.py
@@ -19,5 +19,9 @@ class BackdoorData(DatasetConfig):
             "backdoor": self.backdoor,
         }
 
+    @property
+    def num_classes(self):
+        return self.original.num_classes
+
     def _build(self):
         return self.original._build()

--- a/src/cupbearer/data/pytorch.py
+++ b/src/cupbearer/data/pytorch.py
@@ -5,7 +5,7 @@ from torch.utils.data import Dataset
 from cupbearer.utils.utils import get_object, mutable_field
 
 from . import DatasetConfig
-from ._shared import ToNumpy, Transform, Resize
+from ._shared import Resize, ToNumpy, Transform
 
 
 @dataclass(kw_only=True)
@@ -16,7 +16,7 @@ class PytorchConfig(DatasetConfig):
 
     @property
     def _dataset_kws(self):
-        '''The keyword arguments passed to the dataset constructor.'''
+        """The keyword arguments passed to the dataset constructor."""
         return {
             "root": "data",
             "train": self.train,
@@ -42,16 +42,19 @@ class CIFAR10(PytorchConfig):
 @dataclass
 class GTSRB(PytorchConfig):
     name: str = "torchvision.datasets.GTSRB"
-    transforms: dict[str, Transform] = mutable_field({
-        "resize": Resize(size=(32, 32)),
-        "to_numpy": ToNumpy(),
-    })
+    transforms: dict[str, Transform] = mutable_field(
+        {
+            "resize": Resize(size=(32, 32)),
+            "to_numpy": ToNumpy(),
+        }
+    )
 
     @property
     def _dataset_kws(self):
         # GTSRB takes split as keyword instead of train
         return dict(
-            (key, val) if key != "train"
+            (key, val)
+            if key != "train"
             else ("split", "train" if self.train else "test")
             for key, val in super()._dataset_kws.items()
         )

--- a/src/cupbearer/data/pytorch.py
+++ b/src/cupbearer/data/pytorch.py
@@ -11,6 +11,7 @@ from ._shared import Resize, ToNumpy, Transform
 @dataclass(kw_only=True)
 class PytorchConfig(DatasetConfig):
     name: str
+    num_classes: int
     train: bool = True
     transforms: dict[str, Transform] = mutable_field({"to_numpy": ToNumpy()})
 
@@ -32,16 +33,19 @@ class PytorchConfig(DatasetConfig):
 @dataclass
 class MNIST(PytorchConfig):
     name: str = "torchvision.datasets.MNIST"
+    num_classes: int = 10
 
 
 @dataclass
 class CIFAR10(PytorchConfig):
     name: str = "torchvision.datasets.CIFAR10"
+    num_classes: int = 10
 
 
 @dataclass
 class GTSRB(PytorchConfig):
     name: str = "torchvision.datasets.GTSRB"
+    num_classes: int = 43
     transforms: dict[str, Transform] = mutable_field(
         {
             "resize": Resize(size=(32, 32)),

--- a/src/cupbearer/data/pytorch.py
+++ b/src/cupbearer/data/pytorch.py
@@ -5,7 +5,7 @@ from torch.utils.data import Dataset
 from cupbearer.utils.utils import get_object, mutable_field
 
 from . import DatasetConfig
-from ._shared import ToNumpy, Transform
+from ._shared import ToNumpy, Transform, Resize
 
 
 @dataclass(kw_only=True)
@@ -14,14 +14,18 @@ class PytorchConfig(DatasetConfig):
     train: bool = True
     transforms: dict[str, Transform] = mutable_field({"to_numpy": ToNumpy()})
 
+    @property
+    def _dataset_kws(self):
+        '''The keyword arguments passed to the dataset constructor.'''
+        return {
+            "root": "data",
+            "train": self.train,
+            "download": True,
+        }
+
     def _build(self) -> Dataset:
         dataset_cls = get_object(self.name)
-        # TODO: Many torchvision datasets don't have these arguments, let alone other
-        # pytorch datasets. Maybe we should have a more general kwargs settings,
-        # or maybe trying to have one general class for this doesn't make sense anyway.
-        dataset = dataset_cls(  # type: ignore
-            root="data", train=self.train, download=True
-        )
+        dataset = dataset_cls(**self._dataset_kws)  # type: ignore
         return dataset
 
 
@@ -33,3 +37,21 @@ class MNIST(PytorchConfig):
 @dataclass
 class CIFAR10(PytorchConfig):
     name: str = "torchvision.datasets.CIFAR10"
+
+
+@dataclass
+class GTSRB(PytorchConfig):
+    name: str = "torchvision.datasets.GTSRB"
+    transforms: dict[str, Transform] = mutable_field({
+        "resize": Resize(size=(32, 32)),
+        "to_numpy": ToNumpy(),
+    })
+
+    @property
+    def _dataset_kws(self):
+        # GTSRB takes split as keyword instead of train
+        return dict(
+            (key, val) if key != "train"
+            else ("split", "train" if self.train else "test")
+            for key, val in super()._dataset_kws.items()
+        )

--- a/src/cupbearer/scripts/conf/train_classifier_conf.py
+++ b/src/cupbearer/scripts/conf/train_classifier_conf.py
@@ -19,12 +19,19 @@ class Config(ScriptConfig):
     num_epochs: int = 10
     batch_size: int = 128
     max_batch_size: int = 2048
-    num_classes: int = 10
     max_steps: Optional[int] = None
     wandb: bool = False
     dir: DirConfig = mutable_field(
         DirConfig, base=os.path.join("logs", "train_classifier")
     )
+
+    @property
+    def num_classes(self):
+        return self.train_data.num_classes
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.model.output_dim = self.num_classes
 
     def _set_debug(self):
         super()._set_debug()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -130,7 +130,7 @@ def test_pipeline(tmp_path, capsys):
     cfg = parse(
         train_classifier_conf.Config,
         args=f"--debug_with_logging --dir.full {tmp_path / 'wanet'} "
-        "--train_data backdoor --train_data.original mnist "
+        "--train_data backdoor --train_data.original gtsrb "
         "--train_data.backdoor wanet --model mlp",
         argument_generation_mode=ArgumentGenerationMode.NESTED,
     )


### PR DESCRIPTION
In order to add the dataset there are a few notable changes:
 - add resize transform to `_shared.py` because GTSRB has inhomogenous image sizes
 - turn `adapt_transform` to `AdaptedTransform` class
 - add `_dataset_kws` property to `PytorchConfig` instead to make subclassing more flexible
 - add gtsrb to the wanet test in `test_pipeline.py` this means downloading an extra dataset to run pytest so might not be what we want