### PR TITLE
Enable storing and loading backdoors

### DIFF
--- a/src/cupbearer/data/_shared.py
+++ b/src/cupbearer/data/_shared.py
@@ -19,6 +19,14 @@ class Transform(BaseConfig, ABC):
     def __call__(self, sample):
         pass
 
+    def store(self, basepath):
+        """Save transformer state to reproduce instance later."""
+        pass
+
+    def load(self, basepath):
+        """Load transformer state to reproduce stored instance."""
+        pass
+
 
 @dataclass(kw_only=True)
 class DatasetConfig(BaseConfig, ABC):

--- a/src/cupbearer/scripts/conf/eval_detector_conf.py
+++ b/src/cupbearer/scripts/conf/eval_detector_conf.py
@@ -13,6 +13,7 @@ class Config(ScriptConfig):
     detector: DetectorConfig = config_group(DetectorConfig)
     save_config: bool = False
     pbar: bool = field(action="store_true")
+    no_load: bool = field(action="store_true")
 
     def _set_debug(self):
         super()._set_debug()

--- a/src/cupbearer/scripts/conf/train_detector_conf.py
+++ b/src/cupbearer/scripts/conf/train_detector_conf.py
@@ -5,7 +5,7 @@ from cupbearer.detectors import DetectorConfig
 from cupbearer.tasks import TaskConfigBase
 from cupbearer.utils.config_groups import config_group
 from cupbearer.utils.scripts import DirConfig, ScriptConfig
-from simple_parsing.helpers import mutable_field
+from simple_parsing.helpers import field, mutable_field
 
 
 @dataclass(kw_only=True)
@@ -15,3 +15,4 @@ class Config(ScriptConfig):
     dir: DirConfig = mutable_field(
         DirConfig, base=os.path.join("logs", "train_detector")
     )
+    no_load: bool = field(action="store_true")

--- a/src/cupbearer/scripts/eval_detector.py
+++ b/src/cupbearer/scripts/eval_detector.py
@@ -4,6 +4,7 @@ from cupbearer.utils.scripts import run
 
 
 def main(cfg: Config):
+    # Init
     train_data = cfg.task.build_train_data()
     test_data = cfg.task.build_test_data()
     model = cfg.task.build_model()
@@ -15,6 +16,11 @@ def main(cfg: Config):
         save_dir=cfg.dir.path,
     )
 
+    if not cfg.no_load and hasattr(cfg.task, "backdoor"):
+        # Load backdoor from run_path
+        cfg.task.backdoor.load(cfg.task.run_path)
+
+    # Evaluate detector
     detector.eval(
         train_dataset=train_data,
         test_dataset=test_data,

--- a/src/cupbearer/scripts/train_classifier.py
+++ b/src/cupbearer/scripts/train_classifier.py
@@ -115,6 +115,10 @@ def main(cfg: Config):
     )
     if cfg.dir.path:
         trainer.save_model()
+        try:
+            cfg.train_data.backdoor.store(cfg.dir.path)
+        except AttributeError:
+            pass
     trainer.close_loggers()
 
 

--- a/src/cupbearer/scripts/train_detector.py
+++ b/src/cupbearer/scripts/train_detector.py
@@ -15,6 +15,10 @@ def main(cfg: Config):
         rng=jax.random.PRNGKey(cfg.seed),
     )
 
+    if not cfg.no_load and hasattr(cfg.task, "backdoor"):
+        # Load backdoor from run_path
+        cfg.task.backdoor.load(cfg.task.run_path)
+
     # We want to convert the train dataclass to a dict, but *not* recursively.
     train_kwargs = vars(cfg.detector.train)
     detector.train(reference_data, **train_kwargs)


### PR DESCRIPTION
A variant of storing and loading backdoors as discussed in https://github.com/ejnnr/cupbearer/issues/4

I didn't find a nice way of handling this for all transforms so only doing it for backdoors now. Will probably need a larger make-over sometime in the future.

This is probably the PR that deviates the most with respect to coding style so far, so feel free to be especially harsh in the code review.