### PR TITLE
Bug fix, add clipping to NoiseBackdoor to not create invalid images

### DIFF
--- a/src/cupbearer/data/backdoors.py
+++ b/src/cupbearer/data/backdoors.py
@@ -7,7 +7,6 @@ import numpy as np
 # with torchvision transforms.
 import torch
 from scipy.ndimage import map_coordinates
-from simple_parsing import field
 
 from ._shared import Transform
 
@@ -65,24 +64,18 @@ class NoiseBackdoor(Transform):
     p_backdoor: float = 1.0
     std: float = 0.3
     target_class: int = 0
-    no_clip: bool = field(action="store_true")
 
     def __post_init__(self):
         super().__post_init__()
         assert 0 <= self.p_backdoor <= 1, "Probability must be between 0 and 1"
 
-    @property
-    def clip(self) -> bool:
-        return not self.no_clip
-
     def __call__(self, sample: Tuple[np.ndarray, int]):
         img, target = sample
         if torch.rand(1) <= self.p_backdoor:
-            assert self.no_clip or np.all(img <= 1), "Image not in range [0, 1]"
+            assert np.all(img <= 1), "Image not in range [0, 1]"
             noise = np.random.normal(0, self.std, img.shape)
             img = img + noise
-            if self.clip:
-                img = np.clip(img, 0, 1)
+            img = np.clip(img, 0, 1)
 
             target = self.target_class
 


### PR DESCRIPTION
The `NoiseBackdoor` triggered an `AssertError` in https://github.com/ejnnr/cupbearer/blob/8b88f30d00cf2536174f7412d44b796f247c8219/src/cupbearer/models/computations.py#L301 for MNIST because some pixels got negative values.

This PR fixes this by clipping the values after adding noise in NoiseBackdoor. Added an option to turn clipping off as well for backwards compatibility.