### PR TITLE
Finetuning baseline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "flax~=0.7.0",
-    "jax~=0.4.13",
+    "jax~=0.4.16",
     "optax~=0.1.7",
     "orbax-checkpoint~=0.2.7",
     "numpy~=1.24.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "flax~=0.7.0",
-    "jax~=0.4.16",
+    "jax~=0.4.11",
     "optax~=0.1.7",
     "orbax-checkpoint~=0.2.7",
     "numpy~=1.24.2",

--- a/src/cupbearer/detectors/__init__.py
+++ b/src/cupbearer/detectors/__init__.py
@@ -2,12 +2,14 @@ from cupbearer.utils.config_groups import register_config_group
 
 from .abstraction import AbstractionDetectorConfig, AdversarialAbstractionConfig
 from .config import DetectorConfig, StoredDetector
+from .finetuning import FinetuningConfig
 from .mahalanobis import MahalanobisConfig
 
 DETECTORS = {
     "abstraction": AbstractionDetectorConfig,
     "adversarial_abstraction": AdversarialAbstractionConfig,
     "mahalanobis": MahalanobisConfig,
+    "finetuning": FinetuningConfig,
     "from_run": StoredDetector,
 }
 

--- a/src/cupbearer/detectors/finetuning.py
+++ b/src/cupbearer/detectors/finetuning.py
@@ -111,9 +111,6 @@ class FinetuningAnomalyDetector(AnomalyDetector):
         kl = jax.scipy.special.rel_entr(original_p, finetuned_p).sum(-1)
         return kl
 
-        # HACK: temporary alternative for testing:
-        # return jnp.sum((original_p - finetuned_p) ** 2, axis=-1)
-
     def _get_trained_variables(self, saving: bool = False):
         return {
             "params": self.finetuned_params,

--- a/src/cupbearer/detectors/finetuning.py
+++ b/src/cupbearer/detectors/finetuning.py
@@ -1,0 +1,149 @@
+from dataclasses import dataclass, field
+
+import jax
+import jax.numpy as jnp
+import optax
+from torch.utils.data import DataLoader
+
+from cupbearer.data import numpy_collate
+from cupbearer.detectors.anomaly_detector import AnomalyDetector
+from cupbearer.detectors.config import DetectorConfig, TrainConfig
+from cupbearer.utils import trainer
+from cupbearer.utils.config_groups import config_group
+from cupbearer.utils.optimizers import Adam, OptimizerConfig
+
+
+class FinetuningTrainer(trainer.TrainerModule):
+    def __init__(self, model, loss_fn, **kwargs):
+        super().__init__(model=model, **kwargs)
+        self.loss_fn = loss_fn
+
+    def create_functions(self):
+        def train_step(state, batch):
+            def loss_fn(params):
+                return self.loss_fn(params, batch)
+
+            loss, grads = jax.value_and_grad(loss_fn)(state.params)
+            state = state.apply_gradients(grads=grads)
+            metrics = {"loss": loss}
+            return state, metrics
+
+        def eval_step(state, batch):
+            loss = self.loss_fn(state.params, batch)
+            metrics = {"loss": loss}
+            return metrics
+
+        return train_step, eval_step
+
+
+class FinetuningAnomalyDetector(AnomalyDetector):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.finetuned_params = None  # Initialize finetuned parameters to None
+
+    def train(
+        self,
+        clean_dataset,
+        optimizer: OptimizerConfig,
+        num_epochs: int = 10,
+        batch_size: int = 128,
+        # Not used, but will be passed by the detector train script
+        debug: bool = False,
+    ):
+        # Create a FinetuningTrainer instance
+        trainer_instance = FinetuningTrainer(
+            model=self.model,
+            loss_fn=self.loss_fn,
+            optimizer=optimizer.build(),
+            log_dir=self.save_path,
+            override_variables={
+                "params": self.params
+            },  # Use existing parameters for initialization
+            example_input=clean_dataset[0][0][None],
+        )
+
+        # Create a DataLoader for the clean dataset
+        clean_loader = DataLoader(
+            dataset=clean_dataset,
+            batch_size=batch_size,
+            collate_fn=numpy_collate,
+        )
+
+        # Finetune the model on the clean dataset
+        trainer_instance.train_model(
+            train_loader=clean_loader,
+            val_loaders={},
+            num_epochs=num_epochs,
+        )
+
+        # Store the finetuned parameters
+        self.finetuned_params = trainer_instance.state.params
+
+    def loss_fn(self, params, batch):
+        inputs, targets = batch
+        logits = self.model.apply({"params": params}, inputs)
+        return optax.softmax_cross_entropy_with_integer_labels(logits, targets).mean()
+
+    def layerwise_scores(self, batch):
+        raise NotImplementedError(
+            "Layerwise scores don't exist for finetuning detector"
+        )
+
+    def scores(self, batch):
+        original_output, _ = self._model(batch)
+
+        if isinstance(batch, (tuple, list)):
+            inputs = batch[0]
+        else:
+            inputs = batch
+        finetuned_output = self.model.apply({"params": self.finetuned_params}, inputs)
+
+        finetuned_p = jax.nn.softmax(finetuned_output, axis=-1)
+        original_p = jax.nn.softmax(original_output, axis=-1)
+
+        # Check whether we're going to get infinities:
+        if jnp.any(jnp.logical_and(finetuned_p == 0, original_p > 0)):
+            # We'd get an error anyway once we compute eval metrics, better to give
+            # a more specific one here.
+            raise ValueError("Infinite KL divergence")
+
+        # TODO: which direction do we want here? Or maybe just some other metric?
+        kl = jax.scipy.special.rel_entr(original_p, finetuned_p).sum(-1)
+        return kl
+
+        # HACK: temporary alternative for testing:
+        # return jnp.sum((original_p - finetuned_p) ** 2, axis=-1)
+
+    def _get_trained_variables(self, saving: bool = False):
+        return {
+            "params": self.finetuned_params,
+        }
+
+    def _set_trained_variables(self, variables):
+        self.finetuned_params = variables["params"]
+
+
+@dataclass
+class FinetuningTrainConfig(TrainConfig):
+    optimizer: OptimizerConfig = config_group(OptimizerConfig, Adam)
+    num_epochs: int = 10
+    batch_size: int = 128
+
+    def setup_and_validate(self):
+        super().setup_and_validate()
+        if self.debug:
+            self.batch_size = 2
+
+
+@dataclass
+class FinetuningConfig(DetectorConfig):
+    train: FinetuningTrainConfig = field(default_factory=FinetuningTrainConfig)
+
+    def build(self, model, params, rng, save_dir) -> FinetuningAnomalyDetector:
+        return FinetuningAnomalyDetector(
+            model=model,
+            params=params,
+            rng=rng,
+            max_batch_size=self.max_batch_size,
+            save_path=save_dir,
+        )

--- a/src/cupbearer/detectors/finetuning.py
+++ b/src/cupbearer/detectors/finetuning.py
@@ -108,7 +108,9 @@ class FinetuningAnomalyDetector(AnomalyDetector):
             # a more specific one here.
             raise ValueError("Infinite KL divergence")
 
-        # TODO: which direction do we want here? Or maybe just some other metric?
+        # This is the same direction of KL divergence that Redwood used in one of their
+        # projects, though I don't know if they had a strong reason for it.
+        # Arguably a symmetric metric would make more sense, but might not matter much.
         kl = jax.scipy.special.rel_entr(original_p, finetuned_p).sum(-1)
         return kl
 

--- a/src/cupbearer/detectors/finetuning.py
+++ b/src/cupbearer/detectors/finetuning.py
@@ -58,7 +58,9 @@ class FinetuningAnomalyDetector(AnomalyDetector):
             override_variables={
                 "params": self.params
             },  # Use existing parameters for initialization
-            example_input=clean_dataset[0][0][None],
+            # clean_dataset[0] is the first element, which is an (image, label) tuple.
+            # The second 0 picks the image, then we add a singleton batch dimension.
+            example_input=clean_dataset[0][0][None, ...],
         )
 
         # Create a DataLoader for the clean dataset

--- a/src/cupbearer/detectors/finetuning.py
+++ b/src/cupbearer/detectors/finetuning.py
@@ -39,7 +39,7 @@ class FinetuningTrainer(trainer.TrainerModule):
 class FinetuningAnomalyDetector(AnomalyDetector):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.finetuned_params = None  # Initialize finetuned parameters to None
+        self.finetuned_params = None
 
     def train(
         self,
@@ -50,7 +50,6 @@ class FinetuningAnomalyDetector(AnomalyDetector):
         # Not used, but will be passed by the detector train script
         debug: bool = False,
     ):
-        # Create a FinetuningTrainer instance
         trainer_instance = FinetuningTrainer(
             model=self.model,
             loss_fn=self.loss_fn,

--- a/src/cupbearer/models/computations.py
+++ b/src/cupbearer/models/computations.py
@@ -236,14 +236,12 @@ class SoftmaxDrop(Step, nn.Module):
 
 
 def constant_init(
-    key: jax.random.KeyArray, shape: Sequence[int], dtype=jnp.float_, value=0.0
+    key: jax.Array, shape: Sequence[int], dtype=jnp.float_, value=0.0
 ) -> jax.Array:
     return jnp.full(shape, value, dtype=dtype)
 
 
-def identity_init(
-    key: jax.random.KeyArray, shape: Sequence[int], dtype=jnp.float_
-) -> jax.Array:
+def identity_init(key: jax.Array, shape: Sequence[int], dtype=jnp.float_) -> jax.Array:
     assert len(shape) >= 2
     assert shape[-1] == shape[-2]
     eye = jnp.eye(shape[-1], dtype=dtype)

--- a/src/cupbearer/scripts/train_classifier.py
+++ b/src/cupbearer/scripts/train_classifier.py
@@ -22,8 +22,9 @@ class ClassificationTrainer(trainer.TrainerModule):
         def losses(params, state, batch):
             images, labels = batch
             logits = state.apply_fn({"params": params}, images)
-            one_hot = jax.nn.one_hot(labels, self.num_classes)
-            losses = optax.softmax_cross_entropy(logits=logits, labels=one_hot)
+            losses = optax.softmax_cross_entropy_with_integer_labels(
+                logits=logits, labels=labels
+            )
             loss = jnp.mean(losses)
             correct = jnp.argmax(logits, -1) == labels
             accuracy = jnp.mean(correct)


### PR DESCRIPTION
This is a very simple detector: it finetunes the model on the clean reference dataset, and then assigns score by checking how different the logits of the finetuned and the original model are. (Higher logit difference = more anomalous)

Even without any hyperparameter tuning etc., this is a decent baseline, e.g. it get ~0.8 AUC for a WaNet/CIFAR10 model for which the Mahalanobis baseline appears to be worse than random (?! worth looking into)

Usage is e.g.:
```bash
python -m cupbearer.scripts.train_detector --detector finetuning --dir.full <output_dir> --task backdoor --task.backdoor wanet --task.path <dir_to_classifier_run> --detector.train.num_epochs 1
```

I upgraded the minimum Jax version to 0.4.16 because the new code needs the KL divergence in `jax.scipy.special`. Also had to make some small changes because the finetuning detector doesn't support layerwise scores, which some of the eval code assumed. The detector can probably be improved (e.g. it's unclear whether the current KL divergence is a good metric, and I didn't optimize the hyperparameters at all).