### PR TITLE
Fix validation set configuration via CLI

### DIFF
--- a/src/cupbearer/data/__init__.py
+++ b/src/cupbearer/data/__init__.py
@@ -1,6 +1,6 @@
 from cupbearer.utils.config_groups import register_config_group, register_config_option
 
-from ._shared import DatasetConfig, ToNumpy, TrainDataFromRun, Transform
+from ._shared import DatasetConfig, NoData, ToNumpy, TrainDataFromRun, Transform
 from ._shared import TestDataConfig as TestDataConfig
 from ._shared import TestDataMix as TestDataMix
 from ._shared import numpy_collate as numpy_collate
@@ -17,6 +17,7 @@ DATASETS = {
     "from_run": TrainDataFromRun,
     "adversarial": AdversarialExampleConfig,
     "toy_features": ToyFeaturesConfig,
+    "none": NoData,
 }
 
 TRANSFORMS = {

--- a/src/cupbearer/data/_shared.py
+++ b/src/cupbearer/data/_shared.py
@@ -242,3 +242,21 @@ class TestDataConfig(DatasetConfig):
         if self.transforms:
             raise ValueError("Transforms are not supported for TestDataConfig.")
         return dataset
+
+
+@dataclass
+class NoData(DatasetConfig):
+    """Dummy class for non-existent datasets.
+
+    This is a workaround because simple_parsing doesn't support None as an option
+    when using subgroups, so we can pass this instead when we mean "no dataset".
+
+    It still needs to be instantiable, but otherwise should raise NotImplementedError
+    on any operation.
+    """
+
+    @property
+    def num_classes(self):
+        raise NotImplementedError
+
+    # build already raises NotImplementedError by default

--- a/src/cupbearer/scripts/conf/train_classifier_conf.py
+++ b/src/cupbearer/scripts/conf/train_classifier_conf.py
@@ -1,13 +1,42 @@
+import dataclasses
 import os
 from dataclasses import dataclass
 from typing import Optional
 
-from cupbearer.data import DatasetConfig
+from cupbearer.data import DatasetConfig, NoData
 from cupbearer.models import CNN, MLP, ModelConfig
-from cupbearer.utils.config_groups import config_group
+from cupbearer.utils.config_groups import (
+    config_group,
+    register_config_group,
+)
 from cupbearer.utils.optimizers import Adam, OptimizerConfig
 from cupbearer.utils.scripts import DirConfig, ScriptConfig
-from simple_parsing.helpers import dict_field, mutable_field
+from cupbearer.utils.utils import BaseConfig
+from simple_parsing.helpers import mutable_field
+
+
+@dataclass(kw_only=True)
+class ValidationConfig(BaseConfig):
+    val: Optional[DatasetConfig] = config_group(DatasetConfig, NoData)
+    clean: Optional[DatasetConfig] = config_group(DatasetConfig, NoData)
+    backdoor: Optional[DatasetConfig] = config_group(DatasetConfig, NoData)
+
+    def items(self) -> list[tuple[str, DatasetConfig]]:
+        res = []
+        for field in dataclasses.fields(self):
+            value = getattr(self, field.name)
+            if isinstance(value, DatasetConfig) and not isinstance(value, NoData):
+                res.append((field.name, value))
+
+        return res
+
+
+register_config_group(
+    ValidationConfig,
+    {
+        "default": ValidationConfig,
+    },
+)
 
 
 @dataclass(kw_only=True)
@@ -15,7 +44,7 @@ class Config(ScriptConfig):
     model: ModelConfig = config_group(ModelConfig)
     train_data: DatasetConfig = config_group(DatasetConfig)
     optim: OptimizerConfig = config_group(OptimizerConfig, Adam)
-    val_data: dict[str, DatasetConfig] = dict_field()
+    val_data: ValidationConfig = config_group(ValidationConfig, ValidationConfig)
     num_epochs: int = 10
     batch_size: int = 128
     max_batch_size: int = 2048


### PR DESCRIPTION
**The problem:** `train_classifier.py` accepts a dictionary of validation datasets as one of its config options. But `simple_parsing` doesn't support parsing dictionaries of dataclasses from the CLI (there's an [issue for lists](https://github.com/lebrice/SimpleParsing/issues/271), I think dictionaries would be trickier if anything because it's less clear what the syntax should be).

**Solution in this PR:** I introduced a new config dataclass `ValidationConfig` which serves as a replacement for the dictionary. The big downside is that it has a finite hard-coded list of possible names (i.e. dict keys) for validation splits (right now they're "val", "clean", and "backdoor"). By default they're all set to a new dummy config, and users can override any of them individually and change their properties etc. from the CLI.

This allows pretty complex validation sets, but the CLI usage quickly becomes verbose. For example, say we want to train on poisoned data, and evaluate performance on clean and backdoor data separately. That could look as follows:
```bash
python -m cupbearer.scripts.train_classifier --train_data backdoor --train_data.original mnist --train_data.backdoor corner --train_data.backdoor.p_backdoor 0.1 --model mlp --num_epochs 2 --val_data.backdoor backdoor --val_data.backdoor.original mnist --val_data.backdoor.backdoor corner --val_data.backdoor.original.train false --val_data.clean mnist --val_data.clean.train false
```
If we go with this approach, one improvement could be to add more special cases for `ValidationConfig` that copy reasonable defaults from the training data. The main change this would require is passing the training data config to `ValidationConfig` somehow. I could look into that but first we should figure out if this is even a reasonable approach overall.
Another thing that could help is just having more aliases, e.g. a separate "mnist_test" config option.

**Alternatives I considered:**
- Add rudimentary support for dicts of dataclasses to `simple_parsing`. This would perhaps be cleanest, but my sense is that it's non-trivial, and we'd then still have the problem of verbose CLI usage
- Just don't support a dict of validation datasets. We could have *only* some list of cases people usually want instead of allowing arbitrary custom configs here. Maybe this is the way to go, especially since the current approach also just supports a hard-coded list of split names. (It's trivial to add new ones though)
- Do our own hacky parsing, where the dict is specified as a string or list of (name, config_name) pairs, e.g. ("validation", "mnist"). This doesn't let you override any arguments to the DatasetConfigs though, e.g. the backdoor example above couldn't be specified.