### PR TITLE
Bugfix wanet validation

### DIFF
--- a/src/cupbearer/data/__init__.py
+++ b/src/cupbearer/data/__init__.py
@@ -5,7 +5,7 @@ from ._shared import TestDataConfig as TestDataConfig
 from ._shared import TestDataMix as TestDataMix
 from ._shared import numpy_collate as numpy_collate
 from .adversarial import AdversarialExampleConfig
-from .backdoors import CornerPixelBackdoor, NoiseBackdoor, WanetBackdoor
+from .backdoors import Backdoor, CornerPixelBackdoor, NoiseBackdoor, WanetBackdoor
 from .pytorch import CIFAR10, GTSRB, MNIST, PytorchConfig
 from .toy_ambiguous_features import ToyFeaturesConfig
 
@@ -22,6 +22,9 @@ DATASETS = {
 
 TRANSFORMS = {
     "to_numpy": ToNumpy,
+}
+
+BACKDOORS = {
     "corner": CornerPixelBackdoor,
     "noise": NoiseBackdoor,
     "wanet": WanetBackdoor,
@@ -29,6 +32,7 @@ TRANSFORMS = {
 
 register_config_group(DatasetConfig, DATASETS)
 register_config_group(Transform, TRANSFORMS)
+register_config_group(Backdoor, BACKDOORS)
 
 # Need to import this after datasets and transforms have been registered,
 # since BackdoorData uses them in config groups.
@@ -36,3 +40,8 @@ register_config_group(Transform, TRANSFORMS)
 from .backdoor_data import BackdoorData  # noqa
 
 register_config_option(DatasetConfig, "backdoor", BackdoorData)
+
+# Similarily ValidationConfig uses DatasetConfig and Backdoor
+from .validation_config import ValidationConfig  # noqa
+
+register_config_group(ValidationConfig, {"default": ValidationConfig})

--- a/src/cupbearer/data/backdoor_data.py
+++ b/src/cupbearer/data/backdoor_data.py
@@ -4,13 +4,14 @@ from dataclasses import dataclass
 
 from cupbearer.data import DatasetConfig
 from cupbearer.data._shared import Transform
+from cupbearer.data.backdoors import Backdoor
 from cupbearer.utils.config_groups import config_group
 
 
 @dataclass
 class BackdoorData(DatasetConfig):
     original: DatasetConfig = config_group(DatasetConfig)
-    backdoor: Transform = config_group(Transform)
+    backdoor: Backdoor = config_group(Backdoor)
 
     @property
     def num_classes(self):

--- a/src/cupbearer/data/backdoors.py
+++ b/src/cupbearer/data/backdoors.py
@@ -175,20 +175,19 @@ class WanetBackdoor(Backdoor):
 
     def store(self, basepath):
         super().store(basepath)
-        logger.debug(
-            f"Storing warping field to {self._get_savefile_fullpath(basepath)}"
-        )
-        try:
-            np.save(self._get_savefile_fullpath(basepath), self.warping_field)
-        except AttributeError:
-            raise RuntimeError("Can't store warping field, it is not initialized.")
+        logger.debug(f"Storing control grid to {self._get_savefile_fullpath(basepath)}")
+        np.save(self._get_savefile_fullpath(basepath), self.control_grid)
 
     def load(self, basepath):
         super().load(basepath)
         logger.debug(
-            f"Loading warping field from {self._get_savefile_fullpath(basepath)}"
+            f"Loading control grid from {self._get_savefile_fullpath(basepath)}"
         )
-        self._warping_field = np.load(self._get_savefile_fullpath(basepath))
+        control_grid = np.load(self._get_savefile_fullpath(basepath))
+        if control_grid.shape[-1] != self.control_grid_width:
+            logger.warning("Control grid width updated from load.")
+            self.control_grid_width = control_grid.shape[-1]
+        self.control_grid = control_grid
 
     def _warp(self, img: np.ndarray, warping_field: np.ndarray) -> np.ndarray:
         if img.ndim == 3:

--- a/src/cupbearer/data/backdoors.py
+++ b/src/cupbearer/data/backdoors.py
@@ -32,6 +32,9 @@ class Backdoor(Transform, ABC):
             return sample
 
         img, label = sample
+
+        # Do changes out of place
+        img = np.copy(img)
         return self.inject_backdoor(img), self.target_class
 
 

--- a/src/cupbearer/data/backdoors.py
+++ b/src/cupbearer/data/backdoors.py
@@ -1,4 +1,5 @@
 import os
+from abc import ABC
 from dataclasses import dataclass
 from typing import Tuple
 
@@ -14,25 +15,39 @@ from ._shared import Transform
 
 
 @dataclass
-class CornerPixelBackdoor(Transform):
+class Backdoor(Transform, ABC):
+    p_backdoor: float = 1.0  # Probability of applying the backdoor
+    target_class: int = 0  # Target class when backdoor is applied
+
+    def __post_init__(self):
+        assert 0 <= self.p_backdoor <= 1, "Probability must be between 0 and 1"
+
+    def inject_backdoor(self, img: np.ndarray):
+        # Not an abstractmethod because e.g. Wanet overrides __call__ instead
+        raise NotImplementedError()
+
+    def __call__(self, sample: Tuple[np.ndarray, int]) -> Tuple[np.ndarray, int]:
+        if torch.rand(1) > self.p_backdoor:
+            # Backdoor inactive, don't do anything
+            return sample
+
+        img, label = sample
+        return self.inject_backdoor(img), self.target_class
+
+
+@dataclass
+class CornerPixelBackdoor(Backdoor):
     """Adds a white/red pixel to the specified corner of the image and sets the target.
 
     For grayscale images, the pixel is set to 255 (white),
     for RGB images it is set to (255, 0, 0) (red).
-
-    Args:
-        probability: Probability of applying the transform.
-        corner: Corner of the image to add the pixel to.
-            Can be one of "top-left", "top-right", "bottom-left", "bottom-right".
-        target_class: Target class to set the image to after the transform is applied.
     """
 
-    p_backdoor: float = 1.0
-    corner: str = "top-left"
-    target_class: int = 0
+    corner: str = "top-left"  # Modify pixel in this corner, Can be one of:
+    # "top-left", "top-right", "bottom-left", "bottom-right".
 
     def __post_init__(self):
-        assert 0 <= self.p_backdoor <= 1, "Probability must be between 0 and 1"
+        super().__post_init__()
         assert self.corner in [
             "top-left",
             "top-right",
@@ -40,13 +55,7 @@ class CornerPixelBackdoor(Transform):
             "bottom-right",
         ], "Invalid corner specified"
 
-    def __call__(self, sample: Tuple[np.ndarray, int]):
-        img, target = sample
-
-        # No backdoor, don't do anything
-        if torch.rand(1) > self.p_backdoor:
-            return img, target
-
+    def inject_backdoor(self, img: np.ndarray):
         # Note that channel dimension is last.
         if self.corner == "top-left":
             img[0, 0] = 1
@@ -57,48 +66,98 @@ class CornerPixelBackdoor(Transform):
         elif self.corner == "bottom-right":
             img[-1, -1] = 1
 
-        return img, self.target_class
+        return img
 
 
 @dataclass
-class NoiseBackdoor(Transform):
-    p_backdoor: float = 1.0
-    std: float = 0.3
-    target_class: int = 0
+class NoiseBackdoor(Backdoor):
+    std: float = 0.3  # Standard deviation of noise
 
-    def __post_init__(self):
-        assert 0 <= self.p_backdoor <= 1, "Probability must be between 0 and 1"
+    def inject_backdoor(self, img: np.ndarray):
+        assert np.all(img <= 1), "Image not in range [0, 1]"
+        noise = np.random.normal(0, self.std, img.shape)
+        img = img + noise
+        img = np.clip(img, 0, 1)
 
-    def __call__(self, sample: Tuple[np.ndarray, int]):
-        img, target = sample
-        if torch.rand(1) <= self.p_backdoor:
-            assert np.all(img <= 1), "Image not in range [0, 1]"
-            noise = np.random.normal(0, self.std, img.shape)
-            img = img + noise
-            img = np.clip(img, 0, 1)
-
-            target = self.target_class
-
-        return img, target
+        return img
 
 
 @dataclass
-class WanetBackdoor(Transform):
+class WanetBackdoor(Backdoor):
     """Implements trigger transform from "Wanet - Imperceptible Warping-based
     Backdoor Attack" by Anh Tuan Nguyen and Anh Tuan Tran, ICLR, 2021."""
 
-    p_backdoor: float = 1.0
-    p_noise: float = 0.0
-    control_grid_width: int = 4
-    warping_strength: float = 0.5
-    target_class: int = 0
-    grid_rescale: float = 1.0
+    p_noise: float = 0.0  # Probability of non-backdoor warping
+    control_grid_width: int = 4  # Side length of unscaled warping field
+    warping_strength: float = 0.5  # Strength of warping effect
+    grid_rescale: float = 1.0  # Factor to rescale grid from warping effect
 
     def __post_init__(self):
+        super().__post_init__()
+        self._control_grid = None
         self._warping_field = None
 
-        p_transform = self.p_backdoor + self.p_noise
-        assert 0 <= p_transform <= 1, "Probability must be between 0 and 1"
+        assert 0 <= self.p_noise <= 1, "Probability must be between 0 and 1"
+        assert (
+            0 <= self.p_noise + self.p_backdoor <= 1
+        ), "Probability must be between 0 and 1"
+
+    @property
+    def control_grid(self) -> np.ndarray:
+        if self._control_grid is None:
+            control_grid_shape = (2, self.control_grid_width, self.control_grid_width)
+            control_grid = 2 * np.random.rand(*control_grid_shape) - 1
+            control_grid = control_grid / np.mean(np.abs(control_grid))
+            # N.B. the 0.5 comes from how the original did their rescaling, see
+            # https://github.com/ejnnr/cupbearer/pull/2#issuecomment-1688338610
+            control_grid = control_grid * 0.5 * self.warping_strength
+            self._control_grid = tuple(control_grid.tolist())
+        else:
+            control_grid = np.array(self._control_grid)
+
+        control_grid_shape = (2, self.control_grid_width, self.control_grid_width)
+        assert control_grid.shape == control_grid_shape
+
+        return control_grid
+
+    @control_grid.setter
+    def control_grid(self, control_grid: np.ndarray):
+        control_grid_shape = (2, self.control_grid_width, self.control_grid_width)
+        if control_grid.shape != control_grid_shape:
+            raise ValueError("Control grid shape is incompatible.")
+        self._control_grid = control_grid
+
+    @property
+    def warping_field(self) -> np.ndarray:
+        if self._warping_field is None:
+            raise AttributeError(
+                "Warping field not initialized, run init_warping_field first"
+            )
+        return self._warping_field
+
+    def init_warping_field(self, px: int, py: int):
+        logger.debug("Generating new warping field")
+        field = np.stack(
+            [
+                map_coordinates(  # map_coordinates and upsample diffs slightly
+                    input=grid,
+                    coordinates=np.mgrid[
+                        0 : (self.control_grid_width - 1) : (py * 1j),
+                        0 : (self.control_grid_width - 1) : (px * 1j),
+                    ],
+                    order=3,
+                    mode="nearest",
+                )
+                for grid in self.control_grid
+            ],
+            axis=0,
+        )
+
+        # Create coordinates by adding to identity field
+        field = field + np.mgrid[0:py, 0:px]
+
+        self._warping_field = field
+        assert self._warping_field.shape == (2, py, px)
 
     @staticmethod
     def _get_savefile_fullpath(basepath):
@@ -109,11 +168,10 @@ class WanetBackdoor(Transform):
         logger.debug(
             f"Storing warping field to {self._get_savefile_fullpath(basepath)}"
         )
-        # TODO If img size is known the transform can be significantly sped up
-        # by pre-computing and saving the full flow field instead.
-        if self._warping_field is None:
-            raise RuntimeError("Can't store warping field, it hasn't been compute yet.")
-        np.save(self._get_savefile_fullpath(basepath), self._warping_field)
+        try:
+            np.save(self._get_savefile_fullpath(basepath), self.warping_field)
+        except AttributeError:
+            raise RuntimeError("Can't store warping field, it is not initialized.")
 
     def load(self, basepath):
         super().load(basepath)
@@ -122,39 +180,44 @@ class WanetBackdoor(Transform):
         )
         self._warping_field = np.load(self._get_savefile_fullpath(basepath))
 
-    def warping_field(self, px, py):
-        if self._warping_field is None:
-            logger.debug("Generating new warping field")
-            control_grid_shape = (2, self.control_grid_width, self.control_grid_width)
-            control_grid = 2 * np.random.rand(*control_grid_shape) - 1
-            control_grid = control_grid / np.mean(np.abs(control_grid))
-            # N.B. the 0.5 comes from how the original did their rescaling, see
-            # https://github.com/ejnnr/cupbearer/pull/2#issuecomment-1688338610
-            control_grid = control_grid * 0.5 * self.warping_strength
-            assert control_grid.shape == control_grid_shape
-            # Scale control grid to size of image
-            field = np.stack(
-                [
-                    map_coordinates(  # map_coordinates and upsample diffs slightly
-                        input=grid,
-                        coordinates=np.mgrid[
-                            0 : (self.control_grid_width - 1) : (py * 1j),
-                            0 : (self.control_grid_width - 1) : (px * 1j),
-                        ],
-                        order=3,
-                        mode="nearest",
-                    )
-                    for grid in control_grid
-                ],
-                axis=0,
+    def _warp(self, img: np.ndarray, warping_field: np.ndarray) -> np.ndarray:
+        if img.ndim == 3:
+            py, px, cs = img.shape
+        else:
+            raise ValueError(
+                "Images are expected to have two spatial dimensions and channels last."
             )
-            # Create coordinates by adding to identity field
-            field = field + np.mgrid[0:py, 0:px]
+        if warping_field.shape != (2, py, px):
+            raise ValueError("Incompatible shape of warping field and image.")
 
-            self._warping_field = field
+        # Rescale and clip to not have values outside image
+        if self.grid_rescale != 1.0:
+            warping_field = warping_field * self.grid_rescale + (
+                1 - self.grid_rescale
+            ) / np.array([py, px]).reshape(2, 1, 1)
+        warping_field = np.clip(
+            warping_field,
+            a_min=0,
+            a_max=np.array([py, px]).reshape(2, 1, 1),
+        )
 
-        assert self._warping_field.shape == (2, py, px)
-        return self._warping_field
+        # Perform warping
+        img = np.stack(
+            [
+                map_coordinates(  # map_coordinates and interpolate diffs slightly
+                    input=img_channel,
+                    coordinates=warping_field,
+                    order=1,
+                    mode="nearest",  # equivalent to clipping to borders?
+                    prefilter=False,
+                )
+                for img_channel in np.moveaxis(img, -1, 0)
+            ],
+            axis=-1,
+        )
+
+        assert img.shape == (py, px, cs)
+        return img
 
     def __call__(self, sample: Tuple[np.ndarray, int]):
         img, target = sample
@@ -162,13 +225,19 @@ class WanetBackdoor(Transform):
         if img.ndim == 3:
             py, px, cs = img.shape
         else:
-            raise NotImplementedError(
+            raise ValueError(
                 "Images are expected to have two spatial dimensions and channels last."
             )
 
+        # Init warping field
+        try:
+            self.warping_field
+        except AttributeError:
+            self.init_warping_field(px, py)
+
         rand_sample = np.random.rand(1)
-        if rand_sample <= self.p_backdoor + self.p_noise:
-            warping_field = self.warping_field(px, py)
+        if rand_sample <= self.p_noise + self.p_backdoor:
+            warping_field = self.warping_field
             if rand_sample < self.p_noise:
                 # If noise mode
                 noise = 2 * np.random.rand(*warping_field.shape) - 1
@@ -177,31 +246,8 @@ class WanetBackdoor(Transform):
                 # If adversary mode
                 target = self.target_class
 
-            # Rescale and clip to not have values outside image
-            if self.grid_rescale != 1.0:
-                warping_field = warping_field * self.grid_rescale + (
-                    1 - self.grid_rescale
-                ) / np.array([py, px]).reshape(2, 1, 1)
-            warping_field = np.clip(
-                warping_field,
-                a_min=0,
-                a_max=np.array([py, px]).reshape(2, 1, 1),
-            )
-
-            # Perform warping
-            img = np.stack(
-                [
-                    map_coordinates(  # map_coordinates and interpolate diffs slightly
-                        input=img_channel,
-                        coordinates=warping_field,
-                        order=1,
-                        mode="nearest",  # equivalent to clipping to borders?
-                        prefilter=False,
-                    )
-                    for img_channel in np.moveaxis(img, -1, 0)
-                ],
-                axis=-1,
-            )
+            # Warp image
+            img = self._warp(img, warping_field)
 
         assert img.shape == (py, px, cs)
 

--- a/src/cupbearer/data/validation_config.py
+++ b/src/cupbearer/data/validation_config.py
@@ -1,0 +1,25 @@
+import dataclasses
+from dataclasses import dataclass
+from typing import Optional
+
+from cupbearer.data._shared import DatasetConfig, NoData
+from cupbearer.utils.config_groups import config_group
+from cupbearer.utils.utils import BaseConfig
+
+
+@dataclass(kw_only=True)
+class ValidationConfig(BaseConfig):
+    # Currently these fields have the same defaults
+    val: Optional[DatasetConfig] = config_group(DatasetConfig, NoData)
+    clean: Optional[DatasetConfig] = config_group(DatasetConfig, NoData)
+    custom: Optional[DatasetConfig] = config_group(DatasetConfig, NoData)
+    backdoor: Optional[DatasetConfig] = config_group(DatasetConfig, NoData)
+
+    def items(self) -> list[tuple[str, DatasetConfig]]:
+        res = []
+        for field in dataclasses.fields(self):
+            value = getattr(self, field.name)
+            if isinstance(value, DatasetConfig) and not isinstance(value, NoData):
+                res.append((field.name, value))
+
+        return res

--- a/src/cupbearer/scripts/conf/train_classifier_conf.py
+++ b/src/cupbearer/scripts/conf/train_classifier_conf.py
@@ -35,6 +35,22 @@ class Config(ScriptConfig):
         if isinstance(self.model, (MLP, CNN)):
             self.model.output_dim = self.num_classes
 
+        # For datasets that are not necessarily deterministic based only on
+        # arguments, this is where validation sets are set to follow train_data
+        if hasattr(self.train_data, "backdoor"):
+            for name, val_config in self.val_data.items():
+                # WanetBackdoor
+                try:
+                    str_factor = (
+                        val_config.backdoor.warping_strength
+                        / self.train_data.backdoor.warping_strength
+                    )
+                    val_config.backdoor.control_grid = (
+                        str_factor * self.train_data.backdoor.control_grid
+                    )
+                except AttributeError:
+                    pass
+
     def setup_and_validate(self):
         super().setup_and_validate()
         if self.debug:

--- a/src/cupbearer/scripts/conf/train_classifier_conf.py
+++ b/src/cupbearer/scripts/conf/train_classifier_conf.py
@@ -1,42 +1,13 @@
-import dataclasses
 import os
 from dataclasses import dataclass
 from typing import Optional
 
-from cupbearer.data import DatasetConfig, NoData
+from cupbearer.data import DatasetConfig, ValidationConfig
 from cupbearer.models import CNN, MLP, ModelConfig
-from cupbearer.utils.config_groups import (
-    config_group,
-    register_config_group,
-)
+from cupbearer.utils.config_groups import config_group
 from cupbearer.utils.optimizers import Adam, OptimizerConfig
 from cupbearer.utils.scripts import DirConfig, ScriptConfig
-from cupbearer.utils.utils import BaseConfig
 from simple_parsing.helpers import mutable_field
-
-
-@dataclass(kw_only=True)
-class ValidationConfig(BaseConfig):
-    val: Optional[DatasetConfig] = config_group(DatasetConfig, NoData)
-    clean: Optional[DatasetConfig] = config_group(DatasetConfig, NoData)
-    backdoor: Optional[DatasetConfig] = config_group(DatasetConfig, NoData)
-
-    def items(self) -> list[tuple[str, DatasetConfig]]:
-        res = []
-        for field in dataclasses.fields(self):
-            value = getattr(self, field.name)
-            if isinstance(value, DatasetConfig) and not isinstance(value, NoData):
-                res.append((field.name, value))
-
-        return res
-
-
-register_config_group(
-    ValidationConfig,
-    {
-        "default": ValidationConfig,
-    },
-)
 
 
 @dataclass(kw_only=True)

--- a/src/cupbearer/scripts/conf/train_classifier_conf.py
+++ b/src/cupbearer/scripts/conf/train_classifier_conf.py
@@ -2,7 +2,7 @@ import os
 from dataclasses import dataclass
 from typing import Optional
 
-from cupbearer.data import DatasetConfig, ValidationConfig
+from cupbearer.data import BackdoorData, DatasetConfig, ValidationConfig, WanetBackdoor
 from cupbearer.models import CNN, MLP, ModelConfig
 from cupbearer.utils.config_groups import config_group
 from cupbearer.utils.optimizers import Adam, OptimizerConfig
@@ -37,10 +37,10 @@ class Config(ScriptConfig):
 
         # For datasets that are not necessarily deterministic based only on
         # arguments, this is where validation sets are set to follow train_data
-        if hasattr(self.train_data, "backdoor"):
+        if isinstance(self.train_data, BackdoorData):
             for name, val_config in self.val_data.items():
                 # WanetBackdoor
-                try:
+                if isinstance(self.train_data.backdoor, WanetBackdoor):
                     str_factor = (
                         val_config.backdoor.warping_strength
                         / self.train_data.backdoor.warping_strength
@@ -48,8 +48,6 @@ class Config(ScriptConfig):
                     val_config.backdoor.control_grid = (
                         str_factor * self.train_data.backdoor.control_grid
                     )
-                except AttributeError:
-                    pass
 
     def setup_and_validate(self):
         super().setup_and_validate()

--- a/src/cupbearer/tasks/backdoor_detection.py
+++ b/src/cupbearer/tasks/backdoor_detection.py
@@ -4,9 +4,9 @@ from dataclasses import dataclass
 import simple_parsing
 
 from cupbearer.data import (
+    Backdoor,
     CornerPixelBackdoor,
     NoiseBackdoor,
-    Transform,
     WanetBackdoor,
 )
 from cupbearer.data.backdoor_data import BackdoorData
@@ -19,7 +19,7 @@ from . import TaskConfig
 @dataclass(kw_only=True)
 class BackdoorDetection(TaskConfig):
     no_load: bool = simple_parsing.field(action="store_true")
-    backdoor: Transform = simple_parsing.subgroups(
+    backdoor: Backdoor = simple_parsing.subgroups(
         {
             "corner": CornerPixelBackdoor,
             "noise": NoiseBackdoor,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -206,12 +206,16 @@ def test_backdoor_img_changes(clean_image_config, BackdoorConfig):
             p_backdoor=1.0,
         ),
     )
-    for (clean_img, _), (anomalous_img, _) in zip(
+    for clean_sample, (anomalous_img, _) in zip(
         clean_config.build(),
         anomalous_config.build(),
     ):
+        clean_img, _ = clean_sample
+
         # Check that something has changed
-        assert not np.all(clean_img == anomalous_img)
+        assert clean_img is not anomalous_config.backdoor(clean_sample)[0]
+        assert np.any(clean_img != anomalous_config.backdoor(clean_sample)[0])
+        assert np.any(clean_img != anomalous_img)
 
         # Check that pixel values still in valid range
         assert np.min(clean_img) >= 0

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+import numpy as np
 import pytest
 
 # We shouldn't import TestDataMix directly because that will make pytest think
@@ -31,6 +32,42 @@ class DummyConfig(data.DatasetConfig):
 
     def _build(self) -> Dataset:
         return DummyDataset(self.length, self.value)
+
+
+class DummyImageData(Dataset):
+    def __init__(self, length: int, num_classes: int, shape: tuple[int, int]):
+        self.length = length
+        self.num_classes = num_classes
+        self.img = np.array(
+            [
+                [[i_y % 2, i_x % 2, (i_x + i_y) % 2] for i_x in range(shape[1])]
+                for i_y in range(shape[0])
+            ],
+            dtype=np.float32,
+        )
+
+    def __len__(self):
+        return self.length
+
+    def __getitem__(self, index) -> tuple[np.ndarray, int]:
+        if index >= self.length:
+            raise IndexError
+        return self.img, np.random.randint(self.num_classes)
+
+
+@dataclass
+class DummyImageConfig(data.DatasetConfig):
+    length: int
+    num_classes: int = 10
+    shape: tuple[int, int] = (8, 8)
+
+    def _build(self) -> Dataset:
+        return DummyImageData(self.length, self.num_classes, self.shape)
+
+
+#########################
+# Tests for TestDataMix
+#########################
 
 
 @pytest.fixture
@@ -119,3 +156,123 @@ def test_mixed_max_size(clean_config, anomalous_config):
         assert mixed_data[i] == ("a", 0)
     for i in range(3, 10):
         assert mixed_data[i] == ("b", 1)
+
+
+#######################
+# Tests for Backdoors
+#######################
+
+
+@pytest.fixture
+def clean_image_config():
+    return DummyImageConfig(9)
+
+
+@pytest.fixture(
+    params=[
+        data.backdoors.CornerPixelBackdoor,
+        data.backdoors.NoiseBackdoor,
+        data.backdoors.WanetBackdoor,
+    ]
+)
+def BackdoorConfig(request):
+    return request.param
+
+
+def test_backdoor_relabeling(clean_image_config, BackdoorConfig):
+    clean_image_config.num_classes = 2**63 - 1
+    target_class = 1
+    data_config = data.BackdoorData(
+        original=clean_image_config,
+        backdoor=BackdoorConfig(
+            p_backdoor=1.0,
+            target_class=target_class,
+        ),
+    )
+    for img, label in data_config.build():
+        assert label == target_class
+
+
+def test_backdoor_img_changes(clean_image_config, BackdoorConfig):
+    clean_config = data.BackdoorData(
+        original=clean_image_config,
+        backdoor=BackdoorConfig(
+            p_backdoor=0.0,
+        ),
+    )
+    anomalous_config = data.BackdoorData(
+        original=clean_image_config,
+        backdoor=BackdoorConfig(
+            p_backdoor=1.0,
+        ),
+    )
+    for (clean_img, _), (anomalous_img, _) in zip(
+        clean_config.build(),
+        anomalous_config.build(),
+    ):
+        # Check that something has changed
+        assert not np.all(clean_img == anomalous_img)
+
+        # Check that pixel values still in valid range
+        assert np.min(clean_img) >= 0
+        assert np.min(anomalous_img) >= 0
+        assert np.max(clean_img) <= 1
+        assert np.max(anomalous_img) <= 1
+
+        # Check that backdoor overall applies a small change on average
+        assert np.mean(clean_img - anomalous_img) < (
+            1.0 / np.sqrt(np.prod(clean_img.shape))
+        )
+
+
+def test_wanet_backdoor(clean_image_config):
+    clean_image_config.num_classes = 2**63 - 1
+    target_class = 1
+    clean_config = data.BackdoorData(
+        original=clean_image_config,
+        backdoor=data.backdoors.WanetBackdoor(
+            p_backdoor=0.0,
+            target_class=target_class,
+        ),
+    )
+    anomalous_config = data.BackdoorData(
+        original=clean_image_config,
+        backdoor=data.backdoors.WanetBackdoor(
+            p_backdoor=1.0,
+            target_class=target_class,
+        ),
+    )
+    noise_config = data.BackdoorData(
+        original=clean_image_config,
+        backdoor=data.backdoors.WanetBackdoor(
+            p_backdoor=0.0,
+            p_noise=1.0,
+            target_class=target_class,
+        ),
+    )
+    for (
+        (clean_img, clean_label),
+        (anoma_img, anoma_label),
+        (noise_img, noise_label),
+    ) in zip(
+        clean_config.build(),
+        anomalous_config.build(),
+        noise_config.build(),
+    ):
+        # Check labels
+        assert clean_label != target_class
+        assert anoma_label == target_class
+        assert noise_label != target_class
+
+        # Check that something has changed
+        assert np.any(clean_img != anoma_img)
+        assert np.any(clean_img != noise_img)
+        assert np.any(anoma_img != noise_img)
+
+        # Check that pixel values still in valid range
+        assert np.min(clean_img) >= 0
+        assert np.min(anoma_img) >= 0
+        assert np.min(noise_img) >= 0
+        assert np.max(clean_img) <= 1
+        assert np.max(anoma_img) <= 1
+        assert np.max(noise_img) <= 1

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -96,6 +96,7 @@ def test_pipeline(tmp_path, capsys):
 
 @pytest.mark.slow
 def test_wanet(tmp_path, capsys):
+    tmp_path.mkdir(exist_ok=True)
     ############################
     # WaNet
     ############################
@@ -124,3 +125,17 @@ def test_wanet(tmp_path, capsys):
         else:
             with pytest.raises(NotImplementedError):
                 data_cfg.build()
+
+    # Check that from_run can load WanetBackdoor properly
+    train_detector_cfg = parse(
+        train_detector_conf.Config,
+        args=f"--debug_with_logging --dir.full {tmp_path / 'wanet-mahalanobis'} "
+        f"--task backdoor --task.backdoor wanet --task.path {tmp_path / 'wanet'} "
+        "--detector mahalanobis",
+        argument_generation_mode=ArgumentGenerationMode.NESTED,
+    )
+    run(train_detector.main, train_detector_cfg)
+    assert np.allclose(
+        train_detector_cfg.task.backdoor.warping_field,
+        cfg.train_data.backdoor.warping_field,
+    )


### PR DESCRIPTION
This PR is about fixing so that the datasets in val_data are using the same warping field for the WanetBackdoor as the training set.

Remaining steps:
 - [x] ~Train detector for BackdoorTask does not work, self.get_path() gives path to train_detector, but should use path to train_classifier~ Problem identified between computer and chair
 - [x] Set _control_grid as Optional argument and initialize in post_init to get it into the config.yaml for reproducibility
 - [x] ~Remove unneeded~ Update store and load commands in backdoor to use control_grid instead