### PR TITLE
Make tasks more flexible

### DIFF
--- a/src/cupbearer/data/__init__.py
+++ b/src/cupbearer/data/__init__.py
@@ -1,9 +1,8 @@
 # ruff: noqa: F401
 from ._shared import (
     DatasetConfig,
-    RemoveMixLabelDataset,
-    TestDataConfig,
-    TestDataMix,
+    MixedData,
+    MixedDataConfig,
     TrainDataFromRun,
 )
 from .adversarial import AdversarialExampleConfig

--- a/src/cupbearer/data/__init__.py
+++ b/src/cupbearer/data/__init__.py
@@ -3,7 +3,9 @@ from ._shared import (
     DatasetConfig,
     MixedData,
     MixedDataConfig,
+    SubsetConfig,
     TrainDataFromRun,
+    split_dataset_cfg,
 )
 from .adversarial import AdversarialExampleConfig
 from .backdoor_data import BackdoorData

--- a/src/cupbearer/data/_shared.py
+++ b/src/cupbearer/data/_shared.py
@@ -86,6 +86,7 @@ class SubsetConfig(DatasetConfig):
         end = int(self.end_fraction * len(full))
         return Subset(full, range(start, end))
 
+    @property
     def num_classes(self) -> int:  # type: ignore
         return self.full_dataset.num_classes
 

--- a/src/cupbearer/data/backdoor_data.py
+++ b/src/cupbearer/data/backdoor_data.py
@@ -12,6 +12,11 @@ class BackdoorData(DatasetConfig):
     original: DatasetConfig
     backdoor: Backdoor
 
+    def get_test_split(self) -> DatasetConfig:
+        return BackdoorData(
+            original=self.original.get_test_split(), backdoor=self.backdoor
+        )
+
     @property
     def num_classes(self):
         return self.original.num_classes

--- a/src/cupbearer/data/pytorch.py
+++ b/src/cupbearer/data/pytorch.py
@@ -1,3 +1,4 @@
+import dataclasses
 from dataclasses import dataclass
 
 from torch.utils.data import Dataset
@@ -24,6 +25,14 @@ class PytorchConfig(DatasetConfig):
     train: bool = True
     transforms: dict[str, Transform] = mutable_field({"to_tensor": ToTensor()})
     default_augmentations: bool = True
+
+    def get_test_split(self) -> DatasetConfig:
+        if self.train:
+            # TODO: this will keep the augmentations around,
+            # which we probably don't want?
+            return dataclasses.replace(self, train=False)
+        else:
+            raise ValueError("This dataset is already a test split.")
 
     def __post_init__(self):
         super().__post_init__()

--- a/src/cupbearer/detectors/__init__.py
+++ b/src/cupbearer/detectors/__init__.py
@@ -1,5 +1,6 @@
 # ruff: noqa: F401
 from .abstraction import AbstractionDetectorConfig
+from .anomaly_detector import AnomalyDetector
 from .config import DetectorConfig, StoredDetector
 from .finetuning import FinetuningConfig
 from .statistical import (

--- a/src/cupbearer/detectors/abstraction/abstraction_detector.py
+++ b/src/cupbearer/detectors/abstraction/abstraction_detector.py
@@ -146,11 +146,14 @@ class AbstractionDetector(ActivationBasedDetector):
 
     def train(
         self,
-        dataset,
+        trusted_data,
+        untrusted_data,
         *,
         num_classes: int,
         train_config: TrainConfig,
     ):
+        if trusted_data is None:
+            raise ValueError("Abstraction detector requires trusted training data.")
         # Possibly we should store this as a submodule to save optimizers and continue
         # training later. But as long as we don't actually make use of that,
         # this is easiest.
@@ -160,7 +163,7 @@ class AbstractionDetector(ActivationBasedDetector):
             optim_cfg=train_config.optimizer,
         )
 
-        train_loader = train_config.get_dataloader(dataset)
+        train_loader = train_config.get_dataloader(trusted_data)
 
         # TODO: implement validation data
         # val_loaders = {

--- a/src/cupbearer/detectors/finetuning.py
+++ b/src/cupbearer/detectors/finetuning.py
@@ -19,26 +19,25 @@ class FinetuningAnomalyDetector(AnomalyDetector):
         # detector or load weights for inference, we'll need to copy in both cases.
         self.finetuned_model = copy.deepcopy(self.model)
 
-    @property
-    def should_train_on_clean_data(self) -> bool:
-        return True
-
     def train(
         self,
-        clean_dataset,
+        trusted_data,
+        untrusted_data,
         *,
         num_classes: int,
         train_config: TrainConfig,
     ):
+        if trusted_data is None:
+            raise ValueError("Finetuning detector requires trusted training data.")
         classifier = Classifier(
             self.finetuned_model,
             num_classes=num_classes,
-            optim_cfg=train_config,
+            optim_cfg=train_config.optimizer,
             save_hparams=False,
         )
 
         # Create a DataLoader for the clean dataset
-        clean_loader = train_config.get_dataloader(clean_dataset)
+        clean_loader = train_config.get_dataloader(trusted_data)
 
         # Finetune the model on the clean dataset
         trainer = train_config.get_trainer(path=self.save_path)

--- a/src/cupbearer/detectors/statistical/mahalanobis_detector.py
+++ b/src/cupbearer/detectors/statistical/mahalanobis_detector.py
@@ -8,9 +8,7 @@ from cupbearer.detectors.statistical.statistical import (
 
 
 class MahalanobisDetector(ActivationCovarianceBasedDetector):
-    @property
-    def should_train_on_clean_data(self) -> bool:
-        return True
+    use_trusted: bool = True
 
     def post_covariance_training(self, train_config: MahalanobisTrainConfig):
         self.inv_covariances = {

--- a/src/cupbearer/detectors/statistical/que_detector.py
+++ b/src/cupbearer/detectors/statistical/que_detector.py
@@ -8,9 +8,7 @@ from cupbearer.detectors.statistical.statistical import (
 
 
 class QuantumEntropyDetector(ActivationCovarianceBasedDetector):
-    @property
-    def should_train_on_clean_data(self) -> bool:
-        return True
+    use_trusted: bool = True
 
     def post_covariance_training(self, train_config: ActivationCovarianceTrainConfig):
         whitening_matrices = {}

--- a/src/cupbearer/detectors/statistical/spectral_detector.py
+++ b/src/cupbearer/detectors/statistical/spectral_detector.py
@@ -13,9 +13,7 @@ class SpectralSignatureDetector(ActivationCovarianceBasedDetector):
     Neural Information Processing Systems (2018).
     """
 
-    @property
-    def should_train_on_clean_data(self) -> bool:
-        return False
+    use_trusted: bool = False
 
     def post_covariance_training(self, train_config: ActivationCovarianceTrainConfig):
         # Calculate top right singular vectors from covariance matrices

--- a/src/cupbearer/scripts/conf/eval_detector_conf.py
+++ b/src/cupbearer/scripts/conf/eval_detector_conf.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass
 
 from cupbearer.detectors import DetectorConfig, StoredDetector
-from cupbearer.tasks import TaskConfigBase
+from cupbearer.tasks import TaskConfig
 from cupbearer.utils.scripts import ScriptConfig
 
 
 @dataclass(kw_only=True)
 class Config(ScriptConfig):
-    task: TaskConfigBase
+    task: TaskConfig
     detector: DetectorConfig | None = None
     save_config: bool = False
     pbar: bool = False

--- a/src/cupbearer/scripts/conf/train_detector_conf.py
+++ b/src/cupbearer/scripts/conf/train_detector_conf.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
 
 from cupbearer.detectors import DetectorConfig
-from cupbearer.tasks import TaskConfigBase
+from cupbearer.tasks import TaskConfig
 from cupbearer.utils.scripts import ScriptConfig
 
 
 @dataclass(kw_only=True)
 class Config(ScriptConfig):
-    task: TaskConfigBase
+    task: TaskConfig
     detector: DetectorConfig

--- a/src/cupbearer/scripts/eval_detector.py
+++ b/src/cupbearer/scripts/eval_detector.py
@@ -6,8 +6,8 @@ from cupbearer.utils.scripts import script
 def main(cfg: Config):
     assert cfg.detector is not None  # make type checker happy
     # Init
-    train_data = cfg.task.build_train_data()
-    test_data = cfg.task.build_test_data()
+    train_data = cfg.task.trusted_data.build()
+    test_data = cfg.task.test_data.build()
     # train_data[0] is the first sample, which is (input, ...), so we need another [0]
     example_input = train_data[0][0]
     model = cfg.task.build_model(input_shape=example_input.shape)

--- a/src/cupbearer/scripts/train_detector.py
+++ b/src/cupbearer/scripts/train_detector.py
@@ -10,8 +10,12 @@ def main(cfg: Config):
 
     if cfg.task.allow_trusted:
         trusted_data = cfg.task.trusted_data.build()
+        if len(trusted_data) == 0:
+            trusted_data = None
     if cfg.task.allow_untrusted:
         untrusted_data = cfg.task.untrusted_data.build()
+        if len(untrusted_data) == 0:
+            untrusted_data = None
 
     example_data = trusted_data or untrusted_data
     if example_data is None:

--- a/src/cupbearer/scripts/train_detector.py
+++ b/src/cupbearer/scripts/train_detector.py
@@ -1,5 +1,3 @@
-import warnings
-
 from cupbearer.utils.scripts import script
 
 from . import EvalDetectorConfig, eval_detector
@@ -8,29 +6,27 @@ from .conf.train_detector_conf import Config
 
 @script
 def main(cfg: Config):
-    reference_data = cfg.task.build_train_data()
-    # reference_data[0] is the first sample, which is (input, ...), so we need another
+    trusted_data = untrusted_data = None
+
+    if cfg.task.allow_trusted:
+        trusted_data = cfg.task.trusted_data.build()
+    if cfg.task.allow_untrusted:
+        untrusted_data = cfg.task.untrusted_data.build()
+
+    example_data = trusted_data or untrusted_data
+    if example_data is None:
+        raise ValueError(
+            f"{type(cfg.task).__name__} does not allow trusted nor untrusted data."
+        )
+    # example_data[0] is the first sample, which is (input, ...), so we need another
     # [0] index
-    example_input = reference_data[0][0]
+    example_input = example_data[0][0]
     model = cfg.task.build_model(input_shape=example_input.shape)
     detector = cfg.detector.build(model=model, save_dir=cfg.path)
 
-    if cfg.task.normal_weight_when_training < 1.0:
-        if not detector.should_train_on_poisoned_data:
-            warnings.warn(
-                f"Detector of type {type(detector).__name__} is not meant"
-                + " to be trained on poisoned samples."
-            )
-    else:
-        if not detector.should_train_on_clean_data:
-            warnings.warn(
-                f"Detector of type {type(detector).__name__} is not meant"
-                + " to be trained without poisoned samples."
-            )
-
-    # We want to convert the train dataclass to a dict, but *not* recursively.
     detector.train(
-        reference_data,
+        trusted_data=trusted_data,
+        untrusted_data=untrusted_data,
         num_classes=cfg.task.num_classes,
         train_config=cfg.detector.train,
     )

--- a/src/cupbearer/tasks/__init__.py
+++ b/src/cupbearer/tasks/__init__.py
@@ -1,5 +1,5 @@
 # ruff: noqa: F401
-from ._config import CustomTask, TaskConfig, TaskConfigBase
+from ._config import CustomTask, TaskConfig
 from .adversarial_examples import AdversarialExampleTask
 from .backdoor_detection import BackdoorDetection
 from .toy_features import ToyFeaturesTask

--- a/src/cupbearer/tasks/backdoor_detection.py
+++ b/src/cupbearer/tasks/backdoor_detection.py
@@ -1,10 +1,9 @@
-from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 
-from cupbearer.data import Backdoor
+from cupbearer.data import Backdoor, DatasetConfig
 from cupbearer.data.backdoor_data import BackdoorData
-from cupbearer.models import StoredModel
+from cupbearer.models import ModelConfig, StoredModel
 from cupbearer.utils.scripts import load_config
 
 from ._config import DebugTaskConfig, TaskConfig
@@ -16,19 +15,28 @@ class BackdoorDetection(TaskConfig):
     backdoor: Backdoor
     no_load: bool = False
 
-    def _init_train_data(self):
-        data_cfg = load_config(self.path, "train_data", BackdoorData)
-        # Remove the backdoor
-        self._train_data = data_cfg.original
+    def __post_init__(self):
+        super().__post_init__()
+        self.backdoored_train_data = load_config(self.path, "train_data", BackdoorData)
 
-    def _get_anomalous_test_data(self):
-        copy = deepcopy(self._train_data)
+    def _get_clean_data(self, train: bool) -> DatasetConfig:
+        if train:
+            return self.backdoored_train_data.original
+        else:
+            return self.backdoored_train_data.original.get_test_split()
+
+    def _get_anomalous_data(self, train: bool) -> DatasetConfig:
         if not self.no_load:
             self.backdoor.load(self.path)
-        return BackdoorData(original=copy, backdoor=self.backdoor)
 
-    def _init_model(self):
-        self._model = StoredModel(path=self.path)
+        # TODO: should we get rid of `self.backdoor` and just use the existing one
+        # from the training run?
+        return BackdoorData(
+            original=self._get_clean_data(train), backdoor=self.backdoor
+        )
+
+    def _get_model(self) -> ModelConfig:
+        return StoredModel(path=self.path)
 
 
 @dataclass

--- a/src/cupbearer/tasks/backdoor_detection.py
+++ b/src/cupbearer/tasks/backdoor_detection.py
@@ -1,39 +1,36 @@
 from dataclasses import dataclass
 from pathlib import Path
 
-from cupbearer.data import Backdoor, DatasetConfig
+from cupbearer.data import DatasetConfig
 from cupbearer.data.backdoor_data import BackdoorData
 from cupbearer.models import ModelConfig, StoredModel
 from cupbearer.utils.scripts import load_config
 
-from ._config import DebugTaskConfig, TaskConfig
+from ._config import DebugTaskConfig, FuzzedTask
 
 
 @dataclass(kw_only=True)
-class BackdoorDetection(TaskConfig):
+class BackdoorDetection(FuzzedTask):
     path: Path
-    backdoor: Backdoor
     no_load: bool = False
 
     def __post_init__(self):
-        super().__post_init__()
-        self.backdoored_train_data = load_config(self.path, "train_data", BackdoorData)
+        backdoor_data = load_config(self.path, "train_data", BackdoorData)
+        self._original = backdoor_data.original
+        self._backdoor = backdoor_data.backdoor
+        self._backdoor.p_backdoor = 1.0
 
-    def _get_clean_data(self, train: bool) -> DatasetConfig:
-        if train:
-            return self.backdoored_train_data.original
-        else:
-            return self.backdoored_train_data.original.get_test_split()
-
-    def _get_anomalous_data(self, train: bool) -> DatasetConfig:
         if not self.no_load:
-            self.backdoor.load(self.path)
+            self._backdoor.load(self.path)
 
-        # TODO: should we get rid of `self.backdoor` and just use the existing one
-        # from the training run?
-        return BackdoorData(
-            original=self._get_clean_data(train), backdoor=self.backdoor
-        )
+        # Call this only now that _original and _backdoor are set.
+        super().__post_init__()
+
+    def _get_base_data(self) -> DatasetConfig:
+        return self._original
+
+    def fuzz(self, data: DatasetConfig) -> DatasetConfig:
+        return BackdoorData(original=data, backdoor=self._backdoor)
 
     def _get_model(self) -> ModelConfig:
         return StoredModel(path=self.path)

--- a/src/cupbearer/utils/__init__.py
+++ b/src/cupbearer/utils/__init__.py
@@ -1,4 +1,4 @@
 # ruff: noqa: F401
 from .optimizers import OptimizerConfig
 from .train import DebugTrainConfig, TrainConfig
-from .utils import load, save
+from .utils import inputs_from_batch, load, save

--- a/src/cupbearer/utils/train.py
+++ b/src/cupbearer/utils/train.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import lightning as L
 from lightning.pytorch import callbacks, loggers
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Dataset
 
 from cupbearer.utils.optimizers import OptimizerConfig
 from cupbearer.utils.utils import BaseConfig
@@ -37,7 +37,7 @@ class TrainConfig(BaseConfig):
 
         return callback_list
 
-    def get_dataloader(self, dataset, train=True):
+    def get_dataloader(self, dataset: Dataset, train=True):
         if train:
             return DataLoader(
                 dataset,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,9 +3,6 @@ from dataclasses import dataclass
 import numpy as np
 import pytest
 import torch
-
-# We shouldn't import TestDataMix directly because that will make pytest think
-# it's a test.
 from cupbearer import data
 from torch.utils.data import DataLoader, Dataset
 from torchvision.transforms.functional import InterpolationMode
@@ -87,7 +84,7 @@ def anomalous_dataset():
 
 @pytest.fixture
 def mixed_dataset(clean_dataset, anomalous_dataset):
-    return data.TestDataMix(clean_dataset, anomalous_dataset)
+    return data.MixedData(clean_dataset, anomalous_dataset)
 
 
 @pytest.fixture
@@ -102,7 +99,7 @@ def anomalous_config():
 
 @pytest.fixture
 def mixed_config(clean_config, anomalous_config):
-    return data.TestDataConfig(clean_config, anomalous_config)
+    return data.MixedDataConfig(clean_config, anomalous_config)
 
 
 def test_len(mixed_dataset):
@@ -118,7 +115,7 @@ def test_contents(mixed_dataset):
 
 
 def test_uneven_weight(clean_dataset, anomalous_dataset):
-    mixed_data = data.TestDataMix(clean_dataset, anomalous_dataset, normal_weight=0.3)
+    mixed_data = data.MixedData(clean_dataset, anomalous_dataset, normal_weight=0.3)
     # The 7 anomalous datapoints should be 70% of the dataset, so total length should
     # be 10.
     assert len(mixed_data) == 10
@@ -149,7 +146,7 @@ def test_mixed_max_size(clean_config, anomalous_config):
     anomalous_config.max_size = 23
     # The actual mixed dataset we build now is the same as before: 10 datapoints,
     # 3 normal and 7 anomalous.
-    mixed_config = data.TestDataConfig(clean_config, anomalous_config)
+    mixed_config = data.MixedDataConfig(clean_config, anomalous_config)
     mixed_config.max_size = 10
     mixed_config.normal_weight = 0.3
     mixed_data = mixed_config.build()

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -51,7 +51,9 @@ class TestTrainedStatisticalDetectors:
         detector = Detector(model=model)
 
         detector.train(
-            dataset=dataset,
+            # Just make sure all detectors get the data they need:
+            trusted_data=dataset,
+            untrusted_data=dataset,
             num_classes=7,
             train_config=self.train_config,
         )


### PR DESCRIPTION
Mainly, we'd like to allow detectors that require both trusted and untrusted data (where untrusted data is an unlabeled mix of clean and anomalous data). I ended up making a bunch of other small changes that seemed good while I was doing this:
- Removed `TaskConfigBase`, it was pretty pointless
- Added a `get_test_split()` method to `DatasetConfig`---this will sometimes raise NotImplementedError but for existing datasets we can always make it work, and it's useful when defining tasks. I don't really like the design though, maybe we should just explicitly have "dataset pair" objects?
- Modified adversarial examples a bit to provide test splits
- Replaced the `RemoveLabelMixDataset` with an argument to `TestDataMix` (now `MixedData` since it's not just used for tests). Probably simpler this way

Demo notebook and tests pass but I didn't add new ones to actually test all the mixing logic etc. is correct, just did some manual sanity checks.

@VRehnberg Let me know if you have objections to the design or better ideas for what it should look like, otherwise we can merge this.