### PR TITLE
Fix binary cross entropy loss

### DIFF
--- a/src/cupbearer/data/tampering.py
+++ b/src/cupbearer/data/tampering.py
@@ -27,7 +27,10 @@ class TamperingDataset(torch.utils.data.Dataset):
         sample = self.dataset[idx]
         return (
             sample["text"],
-            torch.tensor([*sample["measurements"], all(sample["measurements"])]),
+            torch.tensor(
+                [*sample["measurements"], all(sample["measurements"])],
+                dtype=torch.float32,
+            ),
         )
         # sample["is_correct"], sample["is_clean"])
 

--- a/src/cupbearer/scripts/_shared.py
+++ b/src/cupbearer/scripts/_shared.py
@@ -53,7 +53,7 @@ class Classifier(L.LightningModule):
     def _get_loss_func(self, task):
         if task == "multiclass":
             return torch.nn.functional.cross_entropy
-        return torch.nn.functional.binary_cross_entropy
+        return torch.nn.functional.binary_cross_entropy_with_logits
 
     def _shared_step(self, batch):
         x, y = batch

--- a/tests/test_tampering.py
+++ b/tests/test_tampering.py
@@ -6,6 +6,15 @@ from cupbearer.scripts import (
     train_classifier,
 )
 
+# Ignore warnings about num_workers
+pytestmark = pytest.mark.filterwarnings(
+    "ignore"
+    ":The '[a-z]*_dataloader' does not have many workers which may be a bottleneck. "
+    "Consider increasing the value of the `num_workers` argument` to "
+    "`num_workers=[0-9]*` in the `DataLoader` to improve performance."
+    ":UserWarning"
+)
+
 
 @pytest.fixture(scope="module")
 def pythia():
@@ -38,6 +47,7 @@ def measurement_predictor_path(pythia, diamond, module_tmp_path):
         path=module_tmp_path,
         max_steps=1,
         logger=False,
+        log_every_n_steps=3,
     )
 
     assert (module_tmp_path / "checkpoints" / "last.ckpt").is_file()


### PR DESCRIPTION
Small fixes for errors that are thrown when not running on MPS. @oliveradk or @ejnnr, if you could check:
 - that it still runs on MPS
 - that it was logits you were expecting to be the output of the model