### PR TITLE
Normalize data

### DIFF
--- a/src/cupbearer/data/pytorch.py
+++ b/src/cupbearer/data/pytorch.py
@@ -5,6 +5,7 @@ from torch.utils.data import Dataset
 from cupbearer.utils import get_object
 
 from .transforms import (
+    Normalize,
     RandomCrop,
     RandomHorizontalFlip,
     RandomRotation,
@@ -20,8 +21,19 @@ class PytorchDataset(Dataset):
     train: bool = True
     transforms: list[Transform] = field(default_factory=lambda: [ToTensor()])
     default_augmentations: bool = True
+    normalize: bool = False
+
+    @property
+    def raw_mean(self):
+        raise NotImplementedError
+
+    @property
+    def raw_std(self):
+        raise NotImplementedError
 
     def __post_init__(self):
+        if self.normalize:
+            self.transforms.append(Normalize(mean=self.raw_mean, std=self.raw_std))
         if self.default_augmentations and self.train:
             # Defaults from WaNet https://openreview.net/pdf?id=eEn8KTtJOx
             self.transforms.append(RandomCrop(p=0.8, padding=5))
@@ -57,12 +69,30 @@ class PytorchDataset(Dataset):
 class MNIST(PytorchDataset):
     name: str = "torchvision.datasets.MNIST"
     num_classes: int = 10
+    normalize: bool = True
+
+    @property
+    def raw_mean(self):
+        return (0.1307,)
+
+    @property
+    def raw_std(self):
+        return (0.3081,)
 
 
 @dataclass
 class CIFAR10(PytorchDataset):
     name: str = "torchvision.datasets.CIFAR10"
     num_classes: int = 10
+    normalize: bool = True
+
+    @property
+    def raw_mean(self):
+        return (0.4914, 0.4822, 0.4465)
+
+    @property
+    def raw_std(self):
+        return (0.247, 0.243, 0.261)
 
     def __post_init__(self):
         super().__post_init__()
@@ -80,6 +110,15 @@ class GTSRB(PytorchDataset):
             ToTensor(),
         ]
     )
+    normalize: bool = True
+
+    @property
+    def raw_mean(self):
+        return (0.485, 0.456, 0.406)
+
+    @property
+    def raw_std(self):
+        return (0.229, 0.224, 0.225)
 
     @property
     def _dataset_kws(self):

--- a/src/cupbearer/data/pytorch.py
+++ b/src/cupbearer/data/pytorch.py
@@ -106,7 +106,7 @@ class GTSRB(PytorchDataset):
     num_classes: int = 43
     transforms: list[Transform] = field(
         default_factory=lambda: [
-            Resize(size=(32, 32)),
+            Resize(size=[32, 32]),
             ToTensor(),
         ]
     )

--- a/src/cupbearer/data/transforms.py
+++ b/src/cupbearer/data/transforms.py
@@ -5,7 +5,11 @@ from typing import Any, Optional
 import torch
 import torchvision.transforms.functional as F
 
-Sample = tuple[torch.Tensor, *tuple[Any, ...]]
+try:
+    # *tuple typing added in Python 3.11
+    Sample = tuple[torch.Tensor, *tuple[Any, ...]]
+except SyntaxError:
+    Sample = tuple[torch.Tensor] | tuple[torch.Tensor, Any]
 
 
 class Transform(ABC):

--- a/src/cupbearer/data/transforms.py
+++ b/src/cupbearer/data/transforms.py
@@ -49,6 +49,20 @@ class ToTensor(AdaptedTransform):
 
 
 @dataclass
+class Normalize(AdaptedTransform):
+    mean: list[float]
+    std: list[float]
+
+    def __img_call__(self, img: torch.Tensor) -> torch.Tensor:
+        return F.normalize(
+            img,
+            mean=self.mean,
+            std=self.std,
+            inplace=False,
+        )
+
+
+@dataclass
 class Resize(AdaptedTransform):
     size: tuple[int, ...]
     interpolation: F.InterpolationMode = F.InterpolationMode.BILINEAR

--- a/src/cupbearer/data/transforms.py
+++ b/src/cupbearer/data/transforms.py
@@ -5,11 +5,7 @@ from typing import Any, Optional
 import torch
 import torchvision.transforms.functional as F
 
-try:
-    # *tuple typing added in Python 3.11
-    Sample = tuple[torch.Tensor, *tuple[Any, ...]]
-except SyntaxError:
-    Sample = tuple[torch.Tensor] | tuple[torch.Tensor, Any]
+Sample = tuple[torch.Tensor] | tuple[torch.Tensor, Any]
 
 
 class Transform(ABC):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -48,232 +48,181 @@ class DummyImageData(Dataset):
         return self.img, self._rng.integers(self.num_classes)
 
 
-#########################
-# Tests for TestDataMix
-#########################
+class TestMixedData:
+    @staticmethod
+    @pytest.fixture
+    def clean_dataset():
+        return DummyDataset(9, "a")
+
+    @staticmethod
+    @pytest.fixture
+    def anomalous_dataset():
+        return DummyDataset(7, "b")
+
+    @staticmethod
+    @pytest.fixture
+    def mixed_dataset(clean_dataset, anomalous_dataset):
+        return data.MixedData(clean_dataset, anomalous_dataset)
+
+    @staticmethod
+    def test_len(mixed_dataset):
+        assert len(mixed_dataset) == 14
+        assert mixed_dataset.normal_len == mixed_dataset.anomalous_len == 7
+
+    @staticmethod
+    def test_contents(mixed_dataset):
+        for i in range(7):
+            assert mixed_dataset[i] == ("a", 0)
+        for i in range(7, 14):
+            assert mixed_dataset[i] == ("b", 1)
+
+    @staticmethod
+    def test_uneven_weight(clean_dataset, anomalous_dataset):
+        mixed_data = data.MixedData(clean_dataset, anomalous_dataset, normal_weight=0.3)
+        # The 7 anomalous datapoints should be 70% of the dataset, so total
+        # length should be 10.
+        assert len(mixed_data) == 10
+        assert mixed_data.normal_len == 3
+        assert mixed_data.anomalous_len == 7
+        for i in range(3):
+            assert mixed_data[i] == ("a", 0)
+        for i in range(3, 10):
+            assert mixed_data[i] == ("b", 1)
 
 
-@pytest.fixture
-def clean_dataset():
-    return DummyDataset(9, "a")
+class DatasetFixtures:
+    @staticmethod
+    @pytest.fixture
+    def clean_image_dataset():
+        return DummyImageData(9, 10, (8, 12))
 
 
-@pytest.fixture
-def anomalous_dataset():
-    return DummyDataset(7, "b")
-
-
-@pytest.fixture
-def mixed_dataset(clean_dataset, anomalous_dataset):
-    return data.MixedData(clean_dataset, anomalous_dataset)
-
-
-def test_len(mixed_dataset):
-    assert len(mixed_dataset) == 14
-    assert mixed_dataset.normal_len == mixed_dataset.anomalous_len == 7
-
-
-def test_contents(mixed_dataset):
-    for i in range(7):
-        assert mixed_dataset[i] == ("a", 0)
-    for i in range(7, 14):
-        assert mixed_dataset[i] == ("b", 1)
-
-
-def test_uneven_weight(clean_dataset, anomalous_dataset):
-    mixed_data = data.MixedData(clean_dataset, anomalous_dataset, normal_weight=0.3)
-    # The 7 anomalous datapoints should be 70% of the dataset, so total length should
-    # be 10.
-    assert len(mixed_data) == 10
-    assert mixed_data.normal_len == 3
-    assert mixed_data.anomalous_len == 7
-    for i in range(3):
-        assert mixed_data[i] == ("a", 0)
-    for i in range(3, 10):
-        assert mixed_data[i] == ("b", 1)
-
-
-#######################
-# Tests for Backdoors
-#######################
-
-
-@pytest.fixture
-def clean_image_dataset():
-    return DummyImageData(9, 10, (8, 12))
-
-
-@pytest.fixture(
-    params=[
-        data.backdoors.CornerPixelBackdoor,
-        data.backdoors.NoiseBackdoor,
-        functools.partial(data.backdoors.WanetBackdoor, path=None),
-    ]
-)
-def backdoor_type(request):
-    return request.param
-
-
-def test_backdoor_relabeling(clean_image_dataset, backdoor_type):
-    target_class = 1
-    dataset = data.BackdoorDataset(
-        original=clean_image_dataset,
-        backdoor=backdoor_type(p_backdoor=1.0, target_class=target_class),
+class TestBackdoors(DatasetFixtures):
+    @staticmethod
+    @pytest.fixture(
+        params=[
+            data.backdoors.CornerPixelBackdoor,
+            data.backdoors.NoiseBackdoor,
+            functools.partial(data.backdoors.WanetBackdoor, path=None),
+        ]
     )
-    for img, label in dataset:
-        assert label == target_class
+    def backdoor_type(request):
+        return request.param
 
-
-def test_backdoor_img_changes(clean_image_dataset, backdoor_type):
-    clean_data = data.BackdoorDataset(
-        original=clean_image_dataset, backdoor=backdoor_type(p_backdoor=0.0)
-    )
-    anomalous_data = data.BackdoorDataset(
-        original=clean_image_dataset, backdoor=backdoor_type(p_backdoor=1.0)
-    )
-    for clean_sample, (anomalous_img, _) in zip(clean_data, anomalous_data):
-        clean_img, _ = clean_sample
-
-        # Check that something has changed
-        assert clean_img is not anomalous_data.backdoor(clean_sample)[0]
-        assert torch.any(clean_img != anomalous_data.backdoor(clean_sample)[0])
-        assert torch.any(clean_img != anomalous_img)
-
-        # Check that pixel values still in valid range
-        assert torch.min(clean_img) >= 0
-        assert torch.min(anomalous_img) >= 0
-        assert torch.max(clean_img) <= 1
-        assert torch.max(anomalous_img) <= 1
-
-        # Check that backdoor overall applies a small change on average
-        assert torch.mean(clean_img - anomalous_img) < (
-            1.0 / np.sqrt(np.prod(clean_img.shape))
+    @staticmethod
+    def test_backdoor_relabeling(clean_image_dataset, backdoor_type):
+        target_class = 1
+        dataset = data.BackdoorDataset(
+            original=clean_image_dataset,
+            backdoor=backdoor_type(p_backdoor=1.0, target_class=target_class),
         )
+        for img, label in dataset:
+            assert label == target_class
 
+    @staticmethod
+    def test_backdoor_img_changes(clean_image_dataset, backdoor_type):
+        clean_data = data.BackdoorDataset(
+            original=clean_image_dataset, backdoor=backdoor_type(p_backdoor=0.0)
+        )
+        anomalous_data = data.BackdoorDataset(
+            original=clean_image_dataset, backdoor=backdoor_type(p_backdoor=1.0)
+        )
+        for clean_sample, (anomalous_img, _) in zip(clean_data, anomalous_data):
+            clean_img, _ = clean_sample
 
-def test_wanet_backdoor(clean_image_dataset):
-    # Pick a target class outside the actual range so we can later tell whether it
-    # was set correctly.
-    target_class = 10_000
-    backdoor = data.backdoors.WanetBackdoor(
-        path=None,
-        p_backdoor=0.0,
-        target_class=target_class,
-    )
-    clean_data = data.BackdoorDataset(
-        original=clean_image_dataset,
-        backdoor=backdoor,
-    )
-    anomalous_data = data.BackdoorDataset(
-        original=clean_image_dataset,
-        backdoor=backdoor.clone(
-            p_backdoor=1.0,
-        ),
-    )
-    noise_data = data.BackdoorDataset(
-        original=clean_image_dataset,
-        backdoor=backdoor.clone(
+            # Check that something has changed
+            assert clean_img is not anomalous_data.backdoor(clean_sample)[0]
+            assert torch.any(clean_img != anomalous_data.backdoor(clean_sample)[0])
+            assert torch.any(clean_img != anomalous_img)
+
+            # Check that pixel values still in valid range
+            assert torch.min(clean_img) >= 0
+            assert torch.min(anomalous_img) >= 0
+            assert torch.max(clean_img) <= 1
+            assert torch.max(anomalous_img) <= 1
+
+            # Check that backdoor overall applies a small change on average
+            assert torch.mean(clean_img - anomalous_img) < (
+                1.0 / np.sqrt(np.prod(clean_img.shape))
+            )
+
+    @staticmethod
+    def test_wanet_backdoor(clean_image_dataset):
+        # Pick a target class outside the actual range so we can later tell whether it
+        # was set correctly.
+        target_class = 10_000
+        backdoor = data.backdoors.WanetBackdoor(
+            path=None,
             p_backdoor=0.0,
-            p_noise=1.0,
-        ),
-    )
-    for (
-        (clean_img, clean_label),
-        (anoma_img, anoma_label),
-        (noise_img, noise_label),
-    ) in zip(clean_data, anomalous_data, noise_data):
-        # Check labels. Our target class is outside the valid range,
-        # so no chance it got randomly chosen.
-        assert clean_label != target_class
-        assert anoma_label == target_class
-        assert noise_label != target_class
-
-        # Check that something has changed
-        assert torch.any(clean_img != anoma_img)
-        assert torch.any(clean_img != noise_img)
-        assert torch.any(anoma_img != noise_img)
-
-        # Check that pixel values still in valid range
-        assert torch.min(clean_img) >= 0
-        assert torch.min(anoma_img) >= 0
-        assert torch.min(noise_img) >= 0
-        assert torch.max(clean_img) <= 1
-        assert torch.max(anoma_img) <= 1
-        assert torch.max(noise_img) <= 1
-    for ds1, ds2 in itertools.combinations(
-        [clean_data, anomalous_data, noise_data],
-        r=2,
-    ):
-        assert torch.allclose(
-            ds1.backdoor.warping_field,
-            ds2.backdoor.warping_field,
+            target_class=target_class,
         )
+        clean_data = data.BackdoorDataset(
+            original=clean_image_dataset,
+            backdoor=backdoor,
+        )
+        anomalous_data = data.BackdoorDataset(
+            original=clean_image_dataset,
+            backdoor=backdoor.clone(
+                p_backdoor=1.0,
+            ),
+        )
+        noise_data = data.BackdoorDataset(
+            original=clean_image_dataset,
+            backdoor=backdoor.clone(
+                p_backdoor=0.0,
+                p_noise=1.0,
+            ),
+        )
+        for (
+            (clean_img, clean_label),
+            (anoma_img, anoma_label),
+            (noise_img, noise_label),
+        ) in zip(clean_data, anomalous_data, noise_data):
+            # Check labels. Our target class is outside the valid range,
+            # so no chance it got randomly chosen.
+            assert clean_label != target_class
+            assert anoma_label == target_class
+            assert noise_label != target_class
 
+            # Check that something has changed
+            assert torch.any(clean_img != anoma_img)
+            assert torch.any(clean_img != noise_img)
+            assert torch.any(anoma_img != noise_img)
 
-def test_wanet_backdoor_on_multiple_workers(
-    clean_image_dataset,
-):
-    anomalous_data = data.BackdoorDataset(
-        original=clean_image_dataset,
-        backdoor=data.backdoors.WanetBackdoor(path=None, p_backdoor=1.0, p_noise=0.0),
-    )
-    data_loader = DataLoader(dataset=anomalous_data, num_workers=2, batch_size=1)
-    imgs = [img for img_batch, label_batch in data_loader for img in img_batch]
-    assert all(torch.allclose(imgs[0], img) for img in imgs)
+            # Check that pixel values still in valid range
+            assert torch.min(clean_img) >= 0
+            assert torch.min(anoma_img) >= 0
+            assert torch.min(noise_img) >= 0
+            assert torch.max(clean_img) <= 1
+            assert torch.max(anoma_img) <= 1
+            assert torch.max(noise_img) <= 1
+        for ds1, ds2 in itertools.combinations(
+            [clean_data, anomalous_data, noise_data],
+            r=2,
+        ):
+            assert isinstance(ds1.backdoor, data.WanetBackdoor)
+            assert isinstance(ds2.backdoor, data.WanetBackdoor)
+            assert torch.allclose(
+                ds1.backdoor.warping_field,
+                ds2.backdoor.warping_field,
+            )
 
-    clean_image = clean_image_dataset.img
-    assert not any(torch.allclose(clean_image, img) for img in imgs)
+    @staticmethod
+    def test_wanet_backdoor_on_multiple_workers(
+        clean_image_dataset,
+    ):
+        anomalous_data = data.BackdoorDataset(
+            original=clean_image_dataset,
+            backdoor=data.backdoors.WanetBackdoor(
+                path=None, p_backdoor=1.0, p_noise=0.0
+            ),
+        )
+        data_loader = DataLoader(dataset=anomalous_data, num_workers=2, batch_size=1)
+        imgs = [img for img_batch, label_batch in data_loader for img in img_batch]
+        assert all(torch.allclose(imgs[0], img) for img in imgs)
 
-
-#######################
-# Tests for Augmentations
-#######################
-
-
-@pytest.fixture(
-    params=[
-        data.RandomCrop(padding=100),
-        data.RandomHorizontalFlip(p=1.0),
-        data.RandomRotation(degrees=10, interpolation=InterpolationMode.BILINEAR),
-    ],
-)
-def augmentation(request):
-    return request.param
-
-
-def test_augmentation(clean_image_dataset, augmentation):
-    # See that augmentation does something unless dud
-    for img, label in clean_image_dataset:
-        aug_img, aug_label = augmentation((img, label))
-        assert label == aug_label
-        assert not torch.allclose(aug_img, img)
-
-    # Try with multiple workers and batches
-    data_loader = DataLoader(
-        dataset=clean_image_dataset, num_workers=2, batch_size=3, drop_last=False
-    )
-    for img, label in data_loader:
-        aug_img, aug_label = augmentation((img, label))
-        assert torch.all(label == aug_label)
-        assert not torch.allclose(aug_img, img)
-
-    # Test that updating p does change augmentation probability
-    augmentation.p = 0.0
-    for img, label in data_loader:
-        aug_img, aug_label = augmentation((img, label))
-        assert torch.all(label == aug_label)
-        assert torch.all(aug_img == img)
-
-
-def test_random_crop(clean_image_dataset):
-    fill_val = 2.75
-    augmentation = data.RandomCrop(
-        padding=100,  # huge padding so that chance of no change is small
-        fill=fill_val,
-    )
-    for img, label in clean_image_dataset:
-        aug_img, aug_label = augmentation((img, label))
-        assert torch.any(aug_img == fill_val)
+        clean_image = clean_image_dataset.img
+        assert not any(torch.allclose(clean_image, img) for img in imgs)
 
 
 @dataclass
@@ -285,7 +234,8 @@ class DummyPytorchDataset(data.PytorchDataset):
     default_augmentations: bool = True
 
     def __post_init__(self):
-        # Because our data are already tensors, we need to disable the default ToTensor
+        # Because our data are already tensors, we need to disable the
+        # default ToTensor
         assert len(self.transforms) == 1
         assert isinstance(self.transforms[0], data.transforms.ToTensor)
         self.transforms = []
@@ -296,32 +246,82 @@ class DummyPytorchDataset(data.PytorchDataset):
         return DummyImageData(self.length, self.num_classes, self.shape)
 
 
-def test_pytorch_dataset_transforms():
-    pytorch_dataset = DummyPytorchDataset()
-    for (_img, _label), (img, label) in zip(pytorch_dataset._build(), pytorch_dataset):
-        assert _label == label
-        assert _img.size() == img.size()
-        assert _img is not img, "Transforms does not seem to have been applied"
+class TestAugmentations(DatasetFixtures):
+    @staticmethod
+    @pytest.fixture(
+        params=[
+            data.RandomCrop(padding=100),
+            data.RandomHorizontalFlip(p=1.0),
+            data.RandomRotation(degrees=10, interpolation=InterpolationMode.BILINEAR),
+        ],
+    )
+    def augmentation(request):
+        return request.param
 
-    transforms = pytorch_dataset.transforms
-    transform_typereps = [repr(type(t)) for t in transforms]
-    augmentation_used = False
-    for trafo in transforms:
-        # Check that transform is unique in list
-        assert transforms.count(trafo) == 1
-        assert transform_typereps.count(repr(type(trafo))) == 1
+    @staticmethod
+    def test_augmentation(clean_image_dataset, augmentation):
+        # See that augmentation does something unless dud
+        for img, label in clean_image_dataset:
+            aug_img, aug_label = augmentation((img, label))
+            assert label == aug_label
+            assert not torch.allclose(aug_img, img)
 
-        # Check transform types
-        assert isinstance(trafo, data.transforms.Transform)
-        if isinstance(trafo, data.transforms.ProbabilisticTransform):
-            augmentation_used = True
-        else:
-            # Augmentations should by default come after all base transforms
-            assert not augmentation_used, "Transform applied after augmentation"
-    assert augmentation_used
+        # Try with multiple workers and batches
+        data_loader = DataLoader(
+            dataset=clean_image_dataset, num_workers=2, batch_size=3, drop_last=False
+        )
+        for img, label in data_loader:
+            aug_img, aug_label = augmentation((img, label))
+            assert torch.all(label == aug_label)
+            assert not torch.allclose(aug_img, img)
 
+        # Test that updating p does change augmentation probability
+        augmentation.p = 0.0
+        for img, label in data_loader:
+            aug_img, aug_label = augmentation((img, label))
+            assert torch.all(label == aug_label)
+            assert torch.all(aug_img == img)
 
-def test_no_augmentations():
-    dataset = DummyPytorchDataset(default_augmentations=False)
-    for trafo in dataset.transforms:
-        assert not isinstance(trafo, data.transforms.ProbabilisticTransform)
+    @staticmethod
+    def test_random_crop(clean_image_dataset):
+        fill_val = 2.75
+        augmentation = data.RandomCrop(
+            padding=100,  # huge padding so that chance of no change is small
+            fill=fill_val,
+        )
+        for img, label in clean_image_dataset:
+            aug_img, aug_label = augmentation((img, label))
+            assert torch.any(aug_img == fill_val)
+
+    @staticmethod
+    def test_pytorch_dataset_transforms():
+        pytorch_dataset = DummyPytorchDataset()
+        for (_img, _label), (img, label) in zip(
+            pytorch_dataset._build(), pytorch_dataset
+        ):
+            assert _label == label
+            assert _img.size() == img.size()
+            assert _img is not img, "Transforms does not seem to have been applied"
+
+        transforms = pytorch_dataset.transforms
+        transform_typereps = [repr(type(t)) for t in transforms]
+        augmentation_used = False
+        for trafo in transforms:
+            # Check that transform is unique in list
+            assert transforms.count(trafo) == 1
+            assert transform_typereps.count(repr(type(trafo))) == 1
+
+            # Check transform types
+            assert isinstance(trafo, data.transforms.Transform)
+            if isinstance(trafo, data.transforms.ProbabilisticTransform):
+                augmentation_used = True
+            else:
+                # Augmentations should by default come after all base transforms
+                assert not augmentation_used, "Transform applied after augmentation"
+        assert augmentation_used
+
+    @staticmethod
+    def test_no_augmentations():
+        dataset = DummyPytorchDataset(default_augmentations=False)
+        for trafo in dataset.transforms:
+            assert not isinstance(trafo, data.transforms.ProbabilisticTransform)


### PR DESCRIPTION
This is probably the limitation that remains for good WaNet noise performance.

TODO:
 - [x] Depends on #35 (so diff is not correct as is)
 - [x] Check that it actually does improve training (not significantly)
 - [x] Discuss transform order

Some backdoors like corner it makes a big difference if they are normalized or not. I can see two different arguments for ordering:
 - In scenarios we mostly care about the problem starts with a poisoned model and in those cases we simply want to train in robust backdoors.
 - For some backdoor detection tasks you're given a poisoned dataset and in those cases image augmentation and other transforms used for training would be applied after the backdoor has been added (though, this might not always be the case in the literature)