### PR TITLE
Show samples where a predictor makes the worst predictions

### DIFF
--- a/src/cupbearer/detectors/anomaly_detector.py
+++ b/src/cupbearer/detectors/anomaly_detector.py
@@ -108,13 +108,7 @@ class AnomalyDetector(ABC):
         test_loader = DataLoader(
             dataset,
             batch_size=batch_size,
-            # For some methods, such as adversarial abstractions, it might matter how
-            # normal/anomalous data is distributed into batches. In that case, we want
-            # to mix them by default.
-            # TODO: we should not let detectors depend on batches this way, they should
-            # require untrusted data instead. Can then remove this and simplify some
-            # code below.
-            # shuffle=True,
+            shuffle=False,
         )
 
         metrics = defaultdict(dict)

--- a/src/cupbearer/detectors/anomaly_detector.py
+++ b/src/cupbearer/detectors/anomaly_detector.py
@@ -99,7 +99,7 @@ class AnomalyDetector(ABC):
         layerwise: bool = False,
         log_yaxis: bool = True,
         show_worst_mistakes: bool = False,
-        show_sample_func: Callable[[Any], Any] | None = None,
+        sample_format_fn: Callable[[Any], Any] | None = None,
     ):
         # Check this explicitly because otherwise things can break in weird ways
         # when we assume that anomaly labels are included.
@@ -206,20 +206,20 @@ class AnomalyDetector(ABC):
                     np.where(labels == 1, layer_scores, np.inf)
                 )[:10]
 
-                print("Normal but high anomaly score:")
+                print("\nNormal but high anomaly score:\n")
                 for idx in false_positives:
                     sample, anomaly_label = dataset[idx]
                     assert anomaly_label == 0
-                    if show_sample_func:
-                        sample = show_sample_func(sample)
+                    if sample_format_fn:
+                        sample = sample_format_fn(sample)
                     print(f"#{idx} ({layer_scores[idx]}): {sample}")
-                print("====================================")
-                print("Anomalous but low anomaly score:")
+                print("\n====================================")
+                print("Anomalous but low anomaly score:\n")
                 for idx in false_negatives:
                     sample, anomaly_label = dataset[idx]
                     assert anomaly_label == 1
-                    if show_sample_func:
-                        sample = show_sample_func(sample)
+                    if sample_format_fn:
+                        sample = sample_format_fn(sample)
                     print(f"#{idx} ({layer_scores[idx]}): {sample}")
 
         if not save_path:

--- a/src/cupbearer/detectors/statistical/helpers.py
+++ b/src/cupbearer/detectors/statistical/helpers.py
@@ -72,22 +72,21 @@ def mahalanobis(
 
 def quantum_entropy(
     whitened_activations: torch.Tensor,
+    untrusted_covariance: torch.Tensor,
+    covariance_norm: torch.Tensor,
     alpha: float = 4,
 ) -> torch.Tensor:
     """Quantum Entropy score.
 
     Args:
         whitened_activations: whitened activations, with shape (batch, dim)
+        untrusted_covariance: covariance matrix of shape (dim, dim)
+        covariance_norm: norm of the covariance matrix
+            (singleton tensor, passed just so it can be cached for speed)
         alpha: QUE hyperparameter
     """
     # Compute QUE-score
-    centered_batch = whitened_activations - whitened_activations.mean(
-        dim=0, keepdim=True
-    )
-    batch_cov = centered_batch.mT @ centered_batch
-
-    batch_cov_norm = torch.linalg.eigvalsh(batch_cov).max()
-    exp_factor = torch.matrix_exp(alpha * batch_cov / batch_cov_norm)
+    exp_factor = torch.matrix_exp(alpha * untrusted_covariance / covariance_norm)
 
     return torch.einsum(
         "bi,ij,jb->b",

--- a/src/cupbearer/detectors/statistical/mahalanobis_detector.py
+++ b/src/cupbearer/detectors/statistical/mahalanobis_detector.py
@@ -17,12 +17,14 @@ class MahalanobisDetector(ActivationCovarianceBasedDetector):
     def post_covariance_training(
         self, rcond: float = 1e-5, relative: bool = False, **kwargs
     ):
-        self.inv_covariances = {k: _pinv(C, rcond) for k, C in self.covariances.items()}
+        self.inv_covariances = {
+            k: _pinv(C, rcond) for k, C in self.covariances["trusted"].items()
+        }
         self.inv_diag_covariances = None
         if relative:
             self.inv_diag_covariances = {
                 k: torch.where(torch.diag(C) > rcond, 1 / torch.diag(C), 0)
-                for k, C in self.covariances.items()
+                for k, C in self.covariances["trusted"].items()
             }
 
     def _individual_layerwise_score(self, name: str, activation: torch.Tensor):
@@ -32,14 +34,14 @@ class MahalanobisDetector(ActivationCovarianceBasedDetector):
 
         distance = mahalanobis(
             activation,
-            self.means[name],
+            self.means["trusted"][name],
             self.inv_covariances[name],
             inv_diag_covariance=inv_diag_covariance,
         )
 
         # Normalize by the number of dimensions (no sqrt since we're using *squared*
         # Mahalanobis distance)
-        return distance / self.means[name].shape[0]
+        return distance / self.means["trusted"][name].shape[0]
 
     def _get_trained_variables(self, saving: bool = False):
         return {

--- a/src/cupbearer/detectors/statistical/spectral_detector.py
+++ b/src/cupbearer/detectors/statistical/spectral_detector.py
@@ -13,19 +13,20 @@ class SpectralSignatureDetector(ActivationCovarianceBasedDetector):
     """
 
     use_trusted: bool = False
+    use_untrusted: bool = True
 
     def post_covariance_training(self, **kwargs):
         # Calculate top right singular vectors from covariance matrices
         self.top_singular_vectors = {
             k: torch.linalg.eigh(cov).eigenvectors[:, -1]
-            for k, cov in self.covariances.items()
+            for k, cov in self.covariances["untrusted"].items()
         }
 
     def _individual_layerwise_score(self, name, activation):
         # ((R(x_i) - \hat{R}) * v) ** 2
         return torch.einsum(
             "bi,i->b",
-            (activation - self.means[name]),
+            (activation - self.means["untrusted"][name]),
             self.top_singular_vectors[name],
         ).square()
 

--- a/src/cupbearer/detectors/statistical/statistical.py
+++ b/src/cupbearer/detectors/statistical/statistical.py
@@ -12,6 +12,7 @@ from cupbearer.detectors.statistical.helpers import update_covariance
 
 class StatisticalDetector(ActivationBasedDetector, ABC):
     use_trusted: bool = True
+    use_untrusted: bool = False
 
     @abstractmethod
     def init_variables(self, activation_sizes: dict[str, torch.Size], device):
@@ -31,48 +32,65 @@ class StatisticalDetector(ActivationBasedDetector, ABC):
         max_steps: int | None = None,
         **kwargs,
     ):
-        # It's important we don't use torch.inference_mode() here, since we want
-        # to be able to override this in certain detectors using torch.enable_grad().
-        with torch.no_grad():
-            if self.use_trusted:
-                if trusted_data is None:
-                    raise ValueError(
-                        f"{self.__class__.__name__} requires trusted training data."
-                    )
-                data = trusted_data
-            else:
-                if untrusted_data is None:
-                    raise ValueError(
-                        f"{self.__class__.__name__} requires untrusted training data."
-                    )
-                data = untrusted_data
+        all_data = {}
+        if self.use_trusted:
+            if trusted_data is None:
+                raise ValueError(
+                    f"{self.__class__.__name__} requires trusted training data."
+                )
+            all_data["trusted"] = trusted_data
+        if self.use_untrusted:
+            if untrusted_data is None:
+                raise ValueError(
+                    f"{self.__class__.__name__} requires untrusted training data."
+                )
+            all_data["untrusted"] = untrusted_data
 
-            # No reason to shuffle, we're just computing statistics
-            data_loader = DataLoader(data, batch_size=batch_size, shuffle=False)
-            example_batch = next(iter(data_loader))
-            example_activations = self.get_activations(example_batch)
+        for case, data in all_data.items():
+            logger.debug(f"Collecting statistics on {case} data")
+            # Common for statistical methods is that the training does not require
+            # gradients, but instead computes summary statistics or similar
+            # It's important we don't use torch.inference_mode() here, since we want
+            # to be able to override this in certain detectors using torch.enable_grad().
+            with torch.no_grad():
+                # No reason to shuffle, we're just computing statistics
+                data_loader = DataLoader(data, batch_size=batch_size, shuffle=False)
+                example_batch = next(iter(data_loader))
+                example_activations = self.get_activations(example_batch)
 
-            # v is an entire batch, v[0] are activations for a single input
-            activation_sizes = {k: v[0].size() for k, v in example_activations.items()}
-            self.init_variables(
-                activation_sizes, device=next(iter(example_activations.values())).device
-            )
+                # v is an entire batch, v[0] are activations for a single input
+                activation_sizes = {
+                    k: v[0].size() for k, v in example_activations.items()
+                }
+                self.init_variables(
+                    activation_sizes,
+                    device=next(iter(example_activations.values())).device,
+                    case=case,
+                )
 
-            if pbar:
-                data_loader = tqdm(data_loader, total=max_steps or len(data_loader))
+                if pbar:
+                    data_loader = tqdm(data_loader, total=max_steps or len(data_loader))
 
-            for i, batch in enumerate(data_loader):
-                if max_steps and i >= max_steps:
-                    break
-                activations = self.get_activations(batch)
-                self.batch_update(activations)
+                for i, batch in enumerate(data_loader):
+                    if max_steps and i >= max_steps:
+                        break
+                    activations = self.get_activations(batch)
+                    self.batch_update(activations, case=case)
 
 
 class ActivationCovarianceBasedDetector(StatisticalDetector):
     """Generic abstract detector that learns means and covariance matrices
     during training."""
 
-    def init_variables(self, activation_sizes: dict[str, torch.Size], device):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._means = {}
+        self._Cs = {}
+        self._ns = {}
+
+    def init_variables(
+        self, activation_sizes: dict[str, torch.Size], device, case: str
+    ):
         if any(len(size) != 1 for size in activation_sizes.values()):
             logger.debug(
                 "Received multi-dimensional activations, will only learn "
@@ -84,23 +102,30 @@ class ActivationCovarianceBasedDetector(StatisticalDetector):
             "Activation sizes: \n"
             + "\n".join(f"{k}: {size}" for k, size in activation_sizes.items())
         )
-        self._means = {
+        self._means[case] = {
             k: torch.zeros(size[-1], device=device)
             for k, size in activation_sizes.items()
         }
-        self._Cs = {
+        self._Cs[case] = {
             k: torch.zeros((size[-1], size[-1]), device=device)
             for k, size in activation_sizes.items()
         }
-        self._ns = {k: 0 for k in activation_sizes.keys()}
+        self._ns[case] = {k: 0 for k in activation_sizes.keys()}
 
-    def batch_update(self, activations: dict[str, torch.Tensor]):
+    def batch_update(self, activations: dict[str, torch.Tensor], case: str):
         for k, activation in activations.items():
             # Flatten the activations to (batch, dim)
             activation = rearrange(activation, "batch ... dim -> (batch ...) dim")
             assert activation.ndim == 2, activation.shape
-            self._means[k], self._Cs[k], self._ns[k] = update_covariance(
-                self._means[k], self._Cs[k], self._ns[k], activation
+            (
+                self._means[case][k],
+                self._Cs[case][k],
+                self._ns[case][k],
+            ) = update_covariance(
+                self._means[case][k],
+                self._Cs[case][k],
+                self._ns[case][k],
+                activation,
             )
 
     @abstractmethod
@@ -151,8 +176,14 @@ class ActivationCovarianceBasedDetector(StatisticalDetector):
         # Post process
         with torch.inference_mode():
             self.means = self._means
-            self.covariances = {k: C / (self._ns[k] - 1) for k, C in self._Cs.items()}
-            if any(torch.count_nonzero(C) == 0 for C in self.covariances.values()):
-                raise RuntimeError("All zero covariance matrix detected.")
+            self.covariances = {}
+            for case, Cs in self._Cs.items():
+                self.covariances[case] = {
+                    k: C / (self._ns[case][k] - 1) for k, C in Cs.items()
+                }
+                if any(
+                    torch.count_nonzero(C) == 0 for C in self.covariances[case].values()
+                ):
+                    raise RuntimeError("All zero covariance matrix detected.")
 
             self.post_covariance_training(**kwargs)

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -75,7 +75,8 @@ class TestTrainedStatisticalDetectors:
         # https://stats.stackexchange.com/a/594218/319192
         detector = self.train_detector(dataset, Model, Detector)
         assert isinstance(detector, ActivationCovarianceBasedDetector)
-        for layer_name, cov in detector.covariances.items():
+        covariances = next(iter(detector.covariances.values()))
+        for layer_name, cov in covariances.items():
             # Check that covariance matrix looks reasonable
             assert cov.ndim == 2
             assert cov.size(0) == cov.size(1)
@@ -84,8 +85,9 @@ class TestTrainedStatisticalDetectors:
 
     def test_inverse_covariance_matrices(self, dataset, Model):
         detector = self.train_detector(dataset, Model, MahalanobisDetector)
-        assert detector.covariances.keys() == detector.inv_covariances.keys()
-        for layer_name, cov in detector.covariances.items():
+        covariances = next(iter(detector.covariances.values()))
+        assert covariances.keys() == detector.inv_covariances.keys()
+        for layer_name, cov in covariances.items():
             inv_cov = detector.inv_covariances[layer_name]
             assert inv_cov.size() == cov.size()
 
@@ -106,9 +108,10 @@ class TestTrainedStatisticalDetectors:
 
     def test_whitening_matrices(self, dataset, Model):
         detector = self.train_detector(dataset, Model, QuantumEntropyDetector)
-        assert detector.covariances.keys() == detector.whitening_matrices.keys()
-        for layer_name, cov in detector.covariances.items():
-            W = detector.whitening_matrices[layer_name]
+        covariances = next(iter(detector.covariances.values()))
+        assert covariances.keys() == detector.trusted_whitening_matrices.keys()
+        for layer_name, cov in covariances.items():
+            W = detector.trusted_whitening_matrices[layer_name]
             assert W.size() == cov.size()
 
             # Check that Whitening matrix computes (pseudo) inverse


### PR DESCRIPTION
Very rudimentary but already seems useful. Usage example (here for a dataset where samples are `(tokens, label)`):
```
detector.eval(
    task.test_data,
    show_worst_mistakes=True,
    # x = (tokens, label), so we want to detokenize x[0]
    sample_format_fn=lambda x: task.model.tokenizer.decode(x[0]),
)
```
`sample_format_fn` defaults to the identity, `show_worst_mistakes` defaults to False so we don't clutter outputs too much.

Relies on #45 , will merge once that's merged.